### PR TITLE
Fix typo in 'use strict'

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1,4 +1,4 @@
-'use stict';
+'use strict';
 
 const path = require('path');
 const os = require('os');


### PR DESCRIPTION
I checked if all files have it. I found a file without this.