### PR TITLE
Add stats coverage for documentation

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -10,7 +10,7 @@ const config = require('lib/config');
 const Package = require('../package.json');
 const scope = process.env.SCOPE_NAME;
 
-const cli = Cli.createCategory('app', {
+const cli = Cli.createCategory(scope, {
     description: Package.description,
     version: Package.version,
     epilog: `

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "start": "./bin/h1.js",
     "build": "pkg --out-path ./dist .",
     "lint": "eslint .",
-    "docs": "node scripts/print_docs.js docs/"
+    "docs": "node scripts/print_docs.js docs/",
+    "docs_coverage": "node scripts/print_docs_coverage.js"
   },
   "dependencies": {
     "chalk": "^2.1.0",

--- a/scripts/print_docs_coverage.js
+++ b/scripts/print_docs_coverage.js
@@ -3,19 +3,11 @@
 require('../scope/h1');
 
 const cli = require('../bin');
-const lib = require('./lib');
-const path = require('path');
-const _ = require('lodash');
-const fs = require('fs');
-
-const table = require('lib/table').table;
-
-const code = '```';
 
 const full_name = (entry) => {
     const names = [entry.name];
     let cur = entry;
-    while(cur.parent){
+    while (cur.parent) {
         names.push(cur.parent.name);
         cur = cur.parent;
     }
@@ -28,14 +20,14 @@ const stats_collector = parent => {
     let examples = 0;
     let total = 0;
 
-    while(missing.length > 0){
+    while (missing.length > 0) {
         const entry = missing.pop();
-        if(entry.children){
+        if (entry.children) {
             missing.push(...entry.children);
         }
-        if(entry.examples){
+        if (entry.examples) {
             examples += 1;
-        }else{
+        } else {
             console.log(`Missing documentation for ${full_name(entry)}`);
         }
         total += 1;

--- a/scripts/print_docs_coverage.js
+++ b/scripts/print_docs_coverage.js
@@ -1,0 +1,55 @@
+'use strict';
+
+require('../scope/h1');
+
+const cli = require('../bin');
+const lib = require('./lib');
+const path = require('path');
+const _ = require('lodash');
+const fs = require('fs');
+
+const table = require('lib/table').table;
+
+const code = '```';
+
+const full_name = (entry) => {
+    const names = [entry.name];
+    let cur = entry;
+    while(cur.parent){
+        names.push(cur.parent.name);
+        cur = cur.parent;
+    }
+
+    return names.reverse().join(' ');
+};
+
+const stats_collector = parent => {
+    const missing = [parent];
+    let examples = 0;
+    let total = 0;
+
+    while(missing.length > 0){
+        const entry = missing.pop();
+        if(entry.children){
+            missing.push(...entry.children);
+        }
+        if(entry.examples){
+            examples += 1;
+        }else{
+            console.log(`Missing documentation for ${full_name(entry)}`);
+        }
+        total += 1;
+    }
+
+    const coverage = Math.round(examples / total * 100);
+    console.log(`${examples} items has examples out of ${total} (${coverage} % coverage).`);
+};
+
+const main = async () => {
+    stats_collector(cli);
+};
+
+main().catch((err) => {
+    console.error('Something terrible happened.', err);
+    process.exit(-1);
+});


### PR DESCRIPTION
To account for the expectation that each command would have examples, even generic or with category-level descriptions, we should measure the coverage of the documentation.