### PR TITLE
Add refactored snapshots tests

### DIFF
--- a/bin/snapshot/tests.js
+++ b/bin/snapshot/tests.js
@@ -8,22 +8,25 @@ const tests = require('../../lib/tests');
 const now = Date.now();
 
 
-ava.test.serial('snapshot create & list & show & rename & delete', async t => {
+ava.test.serial('snapshot life cycle', async t => {
     const vault = await tests.run(`vault create --name vault-snapshot-test-${now} --size 10`);
     const name = `snapshot-test-${now}`;
-    await tests.run(`snapshot create --vault ${vault._id} --name ${name}`);
 
-    const list  = await tests.run('snapshot list');
-    const snapshot = list.find(x => x.name === name);
-    t.true(!!snapshot);
+    await tests.resourceLifeCycle('snapshot', {
+        createParams: `--vault ${vault._id} --name ${name}`,
+    })(t);
 
-    const new_name = `${name}-renamed`;
-    await tests.run(`snapshot rename --snapshot ${snapshot._id} --new-name ${new_name}`);
 
-    const fresh = await tests.run(`snapshot show --snapshot ${snapshot._id}`);
-    t.true(fresh._id === snapshot._id);
-    t.true(fresh.name === new_name);
+    await tests.remove('vault', vault);
+});
 
-    await tests.remove('snapshot', snapshot);
+ava.test.serial('snapshot rename', async t => {
+    const vault = await tests.run(`vault create --name vault-snapshot-test-${now} --size 10`);
+    const name = `snapshot-test-${now}`;
+
+    await tests.resourceRename('snapshot', {
+        createParams: `--vault ${vault._id} --name ${name}`,
+    })(t);
+
     await tests.remove('vault', vault);
 });


### PR DESCRIPTION
This tests fail. ```h1 snapshot create``` returns vault object, instead a new snapshot object.