### PR TITLE
Rename flavour to type

### DIFF
--- a/bin/generic/tag/index.js
+++ b/bin/generic/tag/index.js
@@ -17,7 +17,7 @@ module.exports = resource => {
 
     const subresource = {
         name: 'tag',
-        defaultQuery: '[].{id:_id,name:name,flavour:flavour,state:state,processing:processing}',
+        defaultQuery: '[].{id:_id,name:name,type:flavour,state:state,processing:processing}',
         url: () => 'vm',
         plugins: genericDefaults.plugins,
         commands: ['list', 'show'],

--- a/bin/vm/index.js
+++ b/bin/vm/index.js
@@ -7,7 +7,7 @@ const text = require('lib/text');
 
 const resource = {
     name: 'vm',
-    defaultQuery: '[].{id:_id,name:name,flavour:flavour,state:state,tags:join(\',\',keys(tag || `{}`) ) }',
+    defaultQuery: '[].{id:_id,name:name,type:flavour,state:state,tags:join(\',\',keys(tag || `{}`) ) }',
     url: () => 'vm',
     plugins: genericDefaults.plugins,
     commands: [ 'list', 'show', 'history', 'tag', 'service'],


### PR DESCRIPTION
Left "flavour" in following lines of code:
```
$ grep 'flavour' bin/ lib/ -R -i
bin/service/list/index.js:        choices: [ 'flavour', 'ipv4', 'license', 'metric', 'standard', 'support' ],
bin/service/list/index.js:        flavour: '[].{name: name, maxIPv4:data.vm.maxIPv4, maxhdd:data.vm.maxhdd, maxNetAdp:data.vm.maxNetAdp, cpu:data.vm.cpu, memory:data.vm.memory, PLN: billing.price.PLN, period: billing.period}',
bin/service/list/examples.md:{{command_name}} --resource vm --type flavour 
bin/service/tests.js:    t.true(list.some(d => d.resource === 'vm' && d.type === 'flavour'));
bin/generic/service/change/index.js:            name: 'flavour',
bin/generic/tag/index.js:        defaultQuery: '[].{id:_id,name:name,type:flavour,state:state,processing:processing}',
bin/vm/tests.js:['a1.nano', 'm2.tiny', 'm2.medium'].forEach(flavour => {
bin/vm/tests.js:    ava.serial(`vm life cycle ${flavour}`, async t => {
bin/vm/tests.js:    t.true(started_vm.flavour === 'm2.medium', 'Flavor has not been updated');
bin/vm/index.js:    defaultQuery: '[].{id:_id,name:name,type:flavour,state:state,tags:join(\',\',keys(tag || `{}`) ) }',
bin/vm/create/examples.md:Note (2): To identify available instance type use ```{{scope}} service list --resource vm --type flavour```.
```
It mean service value, example value, key for get data from response, tests, so nothing to update left.