### PR TITLE
Fix plugins of 'project access grant'

### DIFF
--- a/bin/generic/access/user/index.js
+++ b/bin/generic/access/user/index.js
@@ -2,6 +2,7 @@
 
 const Cli = require('lib/cli');
 const text = require('lib/text');
+const defaults = require('bin/generic/defaults');
 const config = require('lib/config');
 
 module.exports = (parent) => {
@@ -28,6 +29,7 @@ module.exports = (parent) => {
         description: `Manage your ${parent.title} access rights`,
         defaultQuery: '[].{id:id,role:role}',
         url: args => `${parent.url(args)}/accessrights`,
+        plugins: defaults.plugins,
         options: options,
         context: {
             grantParams: `--${parent.name} my-${parent.name}`,


### PR DESCRIPTION
```
2019-01-08T11:42:31.397Z node h1 project access grant --email h1-testing\@jawnosc.tk --project 5b34c01bddd5b3c5e9fba642 --role user -o json
usage: h1 project access grant [-h] --email EMAIL [--project PROJECT]
                               [--role {owner,billing,user}]
                               
h1 project access grant: error: Unrecognized arguments: -o json.
  ✖ bin/project/tests.js exited with a non-zero exit code: 2
```