### PR TITLE
Add snapcraft build config

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,25 @@
+name: h1-cli
+base: core18 # the base snap is the execution environment for this snap
+version: git
+summary: HyperOne Command Line Interface
+description: HyperOne Command Line Interface
+
+grade: devel # must be 'stable' to release into candidate/stable channels
+confinement: devmode # use 'strict' once you have the right plugs and slots
+
+parts:
+  cli:
+    plugin: nodejs
+    source: .
+    nodejs-package-manager: npm
+    nodejs-version: '12.4.0'
+    stage-packages:
+      - libgcc1
+      - libstdc++6
+# To list 'stage-packages' use:
+# ldd -v /usr/bin/node  | grep '=>' | awk '{print $4}' | sort -n  | uniq | grep '/' | xargs -n 1 dpkg -S
+apps:
+  h1-cli:
+    command: h1
+  rbx-cli:
+    command: rbx


### PR DESCRIPTION
Heroku uses Snapcraft for CLI distribution.

For intern TODO:

- [ ] Create flow for package publishing (see CI from snapcraft - https://snapcraft.io/build )
- [ ] Update README how to install published package
- [ ] Update quick starter on website how to install
- [ ] Write ```rbx-asciicast-gen``` how to install & use
- [ ] Verify the-right-way for package scoping

To build locally:
```
docker run -v "$PWD":/build -w /build snapcore/snapcraft:stable snapcraft
```
To instal locally:
```
snap install ./h1-cli*.snap --devmode
```
To use installed locally:
```
/snap/bin/h1-cli login --username karol.bregula@siecobywatelska.pl
```
SSH authentication works.

```
$ ls -lah /snap/bin/
razem 8,0K
drwxr-xr-x 2 root root 4,0K cze 23 01:07 .
drwxr-xr-x 5 root root 4,0K cze 23 00:03 ..
lrwxrwxrwx 1 root root   13 cze 23 01:07 h1-cli -> /usr/bin/snap
lrwxrwxrwx 1 root root   13 cze 23 01:07 h1-cli.rbx-cli -> /usr/bin/snap
```