### PR TITLE
Replace '_id' by 'id' globally

### DIFF
--- a/bin/_plugins/outputFormat/index.js
+++ b/bin/_plugins/outputFormat/index.js
@@ -47,7 +47,7 @@ const outputFormat = {
         ;
     },
     json: (args, result) => args.query ? queryFilter(args, result) : result,
-    id: (args, result) => queryFilter(args, result).map(x => x._id || x.id).join('\n'),
+    id: (args, result) => queryFilter(args, result).map(x => x.id || x.id).join('\n'),
     yaml: (args, result) => yaml.safeDump(args.query ? queryFilter(args, result) : result),
 };
 

--- a/bin/_plugins/projectRequired/index.js
+++ b/bin/_plugins/projectRequired/index.js
@@ -17,13 +17,13 @@ module.exports = {
     dirname: __dirname,
     onBeforeConfigure: context => Object.entries(options).forEach(([k, v]) => context.node.addOption(k, v)),
     onBeforeHandler: context => {
-        const apiKey = config.get('profile.project.id');
+        const configProject = config.get('profile.project.id');
         if (context.args['project-select']) { // use command line parameter
             api.setProject(context.args['project-select']);
         } else if (config.getProjectEnv()) { // then try environment variable
             api.setProject(config.getProjectEnv());
-        } else if (apiKey) { // then try config
-            api.setProject(apiKey);
+        } else if (configProject) { // then try config
+            api.setProject(configProject);
         } else if (!config.getTokenEnv()) { // then reject if no service account used
             throw Cli.error.cancelled('You need to select project before you can manage your resources');
         }

--- a/bin/_plugins/projectRequired/index.js
+++ b/bin/_plugins/projectRequired/index.js
@@ -17,7 +17,7 @@ module.exports = {
     dirname: __dirname,
     onBeforeConfigure: context => Object.entries(options).forEach(([k, v]) => context.node.addOption(k, v)),
     onBeforeHandler: context => {
-        const apiKey = config.get('profile.project._id');
+        const apiKey = config.get('profile.project.id');
         if (context.args['project-select']) { // use command line parameter
             api.setProject(context.args['project-select']);
         } else if (config.getProjectEnv()) { // then try environment variable

--- a/bin/agent/index.js
+++ b/bin/agent/index.js
@@ -38,7 +38,7 @@ const schema = {
 
 const resource = {
     name: 'agent',
-    defaultQuery: '[].{id:_id,name:name,type:type,state:state,tags:join(\',\',keys(tag || `{}`) ) }',
+    defaultQuery: '[].{id:id,name:name,type:type,state:state,tags:join(\',\',keys(tag || `{}`) ) }',
     url: () => 'agent',
     plugins: genericDefaults.plugins,
     extraCommands: ['create', 'transfer', 'update'],

--- a/bin/agent/resource/index.js
+++ b/bin/agent/resource/index.js
@@ -8,7 +8,7 @@ module.exports = (parent) => {
 
     const resource = {
         name: 'resource',
-        defaultQuery: '[].{id:_id,name:name,project:project,state:state }',
+        defaultQuery: '[].{id:id,name:name,project:project,state:state }',
         url: args => `${parent.url(args)}/resource`,
         options: parent.options,
         plugins: genericDefaults.plugins,

--- a/bin/agent/tests.js
+++ b/bin/agent/tests.js
@@ -23,7 +23,7 @@ ava.serial('create agent with credentials', async t => {
 
     const agent = await tests.run(`agent create --name ${tests.getName(t.title)} --type container --ssh-file ${sshFilename}`);
 
-    const credentials = await tests.run(`agent credential cert list --agent ${agent._id}`);
+    const credentials = await tests.run(`agent credential cert list --agent ${agent.id}`);
     t.true(credentials.length > 0);
 
     await tests.remove('agent', agent);

--- a/bin/config/tests.js
+++ b/bin/config/tests.js
@@ -39,7 +39,7 @@ ava.serial('test websocket message', async t => {
 
             const event = msg.message.data;
 
-            if (resource._id === msg.resource.data._id) {
+            if (resource.id === msg.resource.data.id) {
                 if (event.state === 'finished') {
                     return resolve(resource);
                 } else if (event.state === 'error') {

--- a/bin/container/index.js
+++ b/bin/container/index.js
@@ -8,7 +8,7 @@ const text = require('lib/text');
 
 const resource = {
     name: 'container',
-    defaultQuery: '[].{id:_id,name:name,image:image,state:state }',
+    defaultQuery: '[].{id:id,name:name,image:image,state:state }',
     url: () => 'container',
     plugins: genericDefaults.plugins,
     earlyAdoptersOnly: true,

--- a/bin/container/tests.js
+++ b/bin/container/tests.js
@@ -68,7 +68,7 @@ ava.serial('container log', async t => {
 ava.serial('container create with volume', async t => {
     const volume = await tests.run(`volume create --name ${tests.getName(t.title, 'volume')} --type volume --size 1`);
     try {
-        const container = await tests.run(`container create --name ${tests.getName(t.title)} ${createParams} --expose 80:80 --volume ${volume._id}/path:/usr/share/nginx/html`);
+        const container = await tests.run(`container create --name ${tests.getName(t.title)} ${createParams} --expose 80:80 --volume ${volume.id}/path:/usr/share/nginx/html`);
         try {
             const res = await request.get(`http://${container.fqdn}/`).ok(res => res.status === 403);
             t.true(res.status === 403);

--- a/bin/database/index.js
+++ b/bin/database/index.js
@@ -28,7 +28,7 @@ const schema = {
 };
 const resource = {
     name: 'database',
-    defaultQuery: '[].{id:_id,name:name,type:type,state:state,tags:join(\',\',keys(tag || `{}`) ) }',
+    defaultQuery: '[].{id:id,name:name,type:type,state:state,tags:join(\',\',keys(tag || `{}`) ) }',
     url: () => 'database',
     plugins: genericDefaults.plugins,
     extraCommands: ['start', 'create', 'stop', 'credential', 'transfer'],

--- a/bin/database/shell/index.js
+++ b/bin/database/shell/index.js
@@ -28,9 +28,9 @@ module.exports = resource => Cli.createCommand('shell', {
 
             const cmdArgs = [
                 '-h', database.fqdn,
-                '-u', database._id,
+                '-u', database.id,
                 '--enable-cleartext-plugin',
-                database._id,
+                database.id,
             ];
 
             if (cmdArgs.verbose) {

--- a/bin/database/tests.js
+++ b/bin/database/tests.js
@@ -55,13 +55,13 @@ const query = {
         const database = await tests.run(`database create --name ${tests.getName(t.title)} --type ${flavour}`);
         await tests.run(`database credential password add --name ${tests.getName(t.title)} --database ${database.id}  --password ${password}`);
         await query[flavour](database, password, 'SELECT 1');
-        await tests.run(`database stop --database ${database._id}`);
+        await tests.run(`database stop --database ${database.id}`);
         await t.throwsAsync(() => query[flavour](database, password, 'SELECT 1'));
-        const stopped_database = await tests.run(`database show --database ${database._id}`);
+        const stopped_database = await tests.run(`database show --database ${database.id}`);
         t.true(stopped_database.state === 'Off');
-        await tests.run(`database start --database ${database._id}`);
+        await tests.run(`database start --database ${database.id}`);
         await query[flavour](database, password, 'SELECT 1');
-        const started_database = await tests.run(`database show --database ${database._id}`);
+        const started_database = await tests.run(`database show --database ${database.id}`);
         t.true(started_database.state === 'Running');
         await tests.remove('database', database);
     });
@@ -78,7 +78,7 @@ const query = {
     ava.serial(`database reachable - ${flavour}`, async t => {
         const password = await tests.getToken();
         const database = await tests.run(`database create --name ${tests.getName(t.title)} --type ${flavour}`);
-        await tests.run(`database credential password add --name ${tests.getName(t.title)} --database ${database._id}  --password ${password}`);
+        await tests.run(`database credential password add --name ${tests.getName(t.title)} --database ${database.id}  --password ${password}`);
 
         try {
             const {results, fields} = await mysqlQuery(database, password, 'SELECT NOW()');
@@ -106,7 +106,7 @@ const query = {
     ava.serial(`database reachable - ${flavour}`, async t => {
         const password = await tests.getToken();
         const database = await tests.run(`database create --name ${tests.getName(t.title)} --type ${flavour}`);
-        await tests.run(`database credential password add --name ${tests.getName(t.title)} --database ${database._id}  --password ${password}`);
+        await tests.run(`database credential password add --name ${tests.getName(t.title)} --database ${database.id}  --password ${password}`);
         try {
             const {results, fields} = await pgQuery(database, password, 'SELECT NOW()');
             t.true(!!results);

--- a/bin/database/tests.js
+++ b/bin/database/tests.js
@@ -10,9 +10,9 @@ const mysqlQuery = async (database, password, query) => {
     console.log(new Date(), `Execute query '${query}' on database '${database.fqdn}'`);
     const connection = await mysql.createConnection({
         host: database.fqdn,
-        user: database._id,
+        user: database.id,
         password: password,
-        database: database._id,
+        database: database.id,
     });
     try {
         const [results, fields] = await connection.execute(query);
@@ -53,7 +53,7 @@ const query = {
     ava.serial(`database stop & start - ${flavour}`, async t => {
         const password = await tests.getToken();
         const database = await tests.run(`database create --name ${tests.getName(t.title)} --type ${flavour}`);
-        await tests.run(`database credential password add --name ${tests.getName(t.title)} --database ${database._id}  --password ${password}`);
+        await tests.run(`database credential password add --name ${tests.getName(t.title)} --database ${database.id}  --password ${password}`);
         await query[flavour](database, password, 'SELECT 1');
         await tests.run(`database stop --database ${database._id}`);
         await t.throwsAsync(() => query[flavour](database, password, 'SELECT 1'));

--- a/bin/disk/create/index.js
+++ b/bin/disk/create/index.js
@@ -100,11 +100,11 @@ module.exports = resource => Cli.createCommand('create', {
 
         if (args['source-file']) {
 
-            const ws = await args.helpers.api.wsUpload(`disk/${disk._id}/upload`);
+            const ws = await args.helpers.api.wsUpload(`disk/${disk.id}/upload`);
 
             await websocketStream.upload(ws, args['source-file'], {progress: !args['no-progress']});
 
-            disk = await args.helpers.api.get(`${resource.url(args)}/${disk._id}`);
+            disk = await args.helpers.api.get(`${resource.url(args)}/${disk.id}`);
         }
 
         return args.helpers.sendOutput(args, disk);

--- a/bin/disk/index.js
+++ b/bin/disk/index.js
@@ -5,7 +5,7 @@ const genericResource = require('bin/generic');
 
 const resource = {
     name: 'disk',
-    defaultQuery: '[].{id:_id,name:name,type:type,size:size,state:state,tags:join(\',\',keys(tag || `{}`) ) }',
+    defaultQuery: '[].{id:id,name:name,type:type,size:size,state:state,tags:join(\',\',keys(tag || `{}`) ) }',
     url: () => 'disk',
     plugins: genericDefaults.plugins,
     extraCommands: ['resize', 'resume', 'transfer'],

--- a/bin/disk/tests.js
+++ b/bin/disk/tests.js
@@ -13,7 +13,7 @@ const ssh = require('../../lib/ssh');
 const now = Date.now();
 
 const download = (resource, destination) => tests.run(`disk download
-                                                       --disk ${resource._id}
+                                                       --disk ${resource.id}
                                                        --destination-file '${destination}'
                                                        --no-progress`);
 
@@ -75,15 +75,15 @@ ava.serial('disk resize', tests.resourceResizeCycle('disk', {
         const consistent_content = await tests.getToken();
         await ssh.execVm(vm, {privateKey: sshKeyPair.privateKey}, `echo '${consistent_content}' > ${testFilePath}; sync;`);
         if (mode === 'offline') {
-            await tests.run(`vm stop  --vm ${vm._id}`);
+            await tests.run(`vm stop  --vm ${vm.id}`);
         }
         await tests.run(`disk create --name ${cloneDisk} --source-disk ${osDisk}`);
         if (mode === 'online') {
-            await tests.run(`vm stop  --vm ${vm._id}`);
+            await tests.run(`vm stop  --vm ${vm.id}`);
         }
-        await tests.run(`vm disk detach --disk ${osDisk} --vm ${vm._id}`);
-        await tests.run(`vm disk attach --disk ${cloneDisk} --vm ${vm._id}`);
-        await tests.run(`vm start --vm ${vm._id}`);
+        await tests.run(`vm disk detach --disk ${osDisk} --vm ${vm.id}`);
+        await tests.run(`vm disk attach --disk ${cloneDisk} --vm ${vm.id}`);
+        await tests.run(`vm start --vm ${vm.id}`);
         const readable_content = await ssh.execVm(vm, {privateKey: sshKeyPair.privateKey},  `cat ${testFilePath}`);
 
         t.true(readable_content.trim() === consistent_content.trim());

--- a/bin/dns/zone/index.js
+++ b/bin/dns/zone/index.js
@@ -14,7 +14,7 @@ const schema = {
 };
 const resource = {
     name: 'zone',
-    defaultQuery: '[].{id:_id,name:name}',
+    defaultQuery: '[].{id:id,name:name}',
     plugins: defaults.plugins,
     url: () => 'dns/zone',
     title: 'DNS Zone',

--- a/bin/firewall/index.js
+++ b/bin/firewall/index.js
@@ -19,7 +19,7 @@ const schema = {
 
 const resource = {
     name: 'firewall',
-    defaultQuery: '[].{id:_id,name:name,network:network,state:state,tags:join(\',\',keys(tag || `{}`) )}',
+    defaultQuery: '[].{id:id,name:name,network:network,state:state,tags:join(\',\',keys(tag || `{}`) )}',
     url: () => 'firewall',
     plugins: genericDefaults.plugins,
     extraCommands: ['transfer', 'create'],

--- a/bin/firewall/rule/index.js
+++ b/bin/firewall/rule/index.js
@@ -7,7 +7,7 @@ module.exports = (table, parent) => {
     const resource = {
         name: table,
         // eslint-disable-next-line quotes
-        defaultQuery: `[].{id:_id, name:name, priority:priority, action: action, filter:join(',',filter), external:join(',',external), internal:join(',',internal)}`,
+        defaultQuery: `[].{id:id, name:name, priority:priority, action: action, filter:join(',',filter), external:join(',',external), internal:join(',',internal)}`,
         plugins: parent.plugins,
         options: {
             firewall: {

--- a/bin/firewall/tests.js
+++ b/bin/firewall/tests.js
@@ -22,17 +22,17 @@ ava.serial('firewall attach & detach', async t => {
     let network = await tests.run(`network create --name network-${name}`);
 
     const firewall = await tests.run(`firewall create ${createParams}`);
-    await tests.run(`firewall attach --firewall ${firewall._id} --network ${network._id}`);
+    await tests.run(`firewall attach --firewall ${firewall.id} --network ${network.id}`);
 
-    const refreshed = await tests.run(`firewall show --firewall ${firewall._id}`);
+    const refreshed = await tests.run(`firewall show --firewall ${firewall.id}`);
     t.true(refreshed.state === 'Attached');
 
-    network = await tests.run(`network show --network ${network._id}`);
-    t.true(network.firewall === firewall._id);
+    network = await tests.run(`network show --network ${network.id}`);
+    t.true(network.firewall === firewall.id);
 
-    await tests.run(`firewall detach --firewall ${firewall._id}`);
+    await tests.run(`firewall detach --firewall ${firewall.id}`);
 
-    network = await tests.run(`network show --network ${network._id}`);
+    network = await tests.run(`network show --network ${network.id}`);
     t.true(!network.firewall);
 
     await tests.remove('firewall', firewall);
@@ -44,17 +44,17 @@ ava.serial('firewall attach & detach', async t => {
         const firewall = await tests.run(`firewall create ${createParams}`);
         const name = `${now}-${table}`;
 
-        const rule = await tests.run(`firewall ${table} add --firewall ${firewall._id} --action allow --priority 300 --filter tcp:80 --external 0.0.0.0/0 --internal 10.177.2.2 --name ${name}`);
+        const rule = await tests.run(`firewall ${table} add --firewall ${firewall.id} --action allow --priority 300 --filter tcp:80 --external 0.0.0.0/0 --internal 10.177.2.2 --name ${name}`);
 
-        const added_list = await tests.run(`firewall ${table} list --firewall ${firewall._id}`);
+        const added_list = await tests.run(`firewall ${table} list --firewall ${firewall.id}`);
         t.true(added_list.some(r => r.name === name));
 
-        const refreshed_rule = await tests.run(`firewall ${table} show --firewall ${firewall._id} --${table} ${rule._id}`);
-        t.true(refreshed_rule.name === rule.name && refreshed_rule._id === rule._id);
+        const refreshed_rule = await tests.run(`firewall ${table} show --firewall ${firewall.id} --${table} ${rule.id}`);
+        t.true(refreshed_rule.name === rule.name && refreshed_rule.id === rule.id);
 
-        await tests.run(`firewall ${table} delete --firewall ${firewall._id} --rule ${rule._id}`);
+        await tests.run(`firewall ${table} delete --firewall ${firewall.id} --rule ${rule.id}`);
 
-        const clean_list = await tests.run(`firewall ${table} list --firewall ${firewall._id}`);
+        const clean_list = await tests.run(`firewall ${table} list --firewall ${firewall.id}`);
         t.true(!clean_list.some(r => r.name === name));
 
         await tests.remove('firewall', firewall);

--- a/bin/generic/credential/index.js
+++ b/bin/generic/credential/index.js
@@ -16,7 +16,7 @@ module.exports = (resource) => {
 
     const defaults = {
         name: 'credential',
-        defaultQuery: '[].{id:_id,name:name,type:type}',
+        defaultQuery: '[].{id:id,name:name,type:type}',
         url: args => `${resource.url(args)}/${args[resource.name]}`,
         commands: [],
         options: options,

--- a/bin/generic/history/index.js
+++ b/bin/generic/history/index.js
@@ -18,7 +18,7 @@ module.exports = resource => {
         options: Object.assign({}, options, resource.options),
         resource: resource,
         handler: args => {
-            args.query = '[].{id:_id,name:name,createdBy:createdBy,queued:queued,state:state}';
+            args.query = '[].{id:id,name:name,createdBy:createdBy,queued:queued,state:state}';
 
             return args.helpers.api
                 .get(`${resource.url(args)}/${args[resource.name]}/queue`)

--- a/bin/generic/payment/index.js
+++ b/bin/generic/payment/index.js
@@ -15,7 +15,7 @@ module.exports = parent => {
     const resource = {
         name: 'payment',
         description: `Manage your payment for ${parent.title}`,
-        defaultQuery: '[].{id:_id, creditsFree:creditsFree, credits:credits, channel:channel, type:type, project:project, createdOn:createdOn}',
+        defaultQuery: '[].{id:id, creditsFree:creditsFree, credits:credits, channel:channel, type:type, project:project, createdOn:createdOn}',
         url: args => `${parent.url(args)}/${args[parent.name]}/payment`,
         params: parent.params,
         options: Object.assign({}, parent.options, options),

--- a/bin/generic/resume/index.js
+++ b/bin/generic/resume/index.js
@@ -28,11 +28,11 @@ module.exports = resource => {
 
             let r = await args.helpers.api.get(`${resource.url(args)}/${args[resource.name]}`);
 
-            const ws = await args.helpers.api.wsUpload(`${resource.url(args)}/${r._id}/upload`);
+            const ws = await args.helpers.api.wsUpload(`${resource.url(args)}/${r.id}/upload`);
 
             await websocketStream.upload(ws, args['source-file']);
 
-            r = await args.helpers.api.get(`${resource.url(args)}/${r._id}`);
+            r = await args.helpers.api.get(`${resource.url(args)}/${r.id}`);
 
             return args.helpers.sendOutput(args, r);
         },

--- a/bin/generic/rule/index.js
+++ b/bin/generic/rule/index.js
@@ -8,7 +8,7 @@ module.exports = (parent) => {
         name: 'rule',
         description: `Manage your ${parent.title} network access control rule`,
         // eslint-disable-next-line quotes
-        defaultQuery: '[].{id:_id,name:name,type:type,value:value}',
+        defaultQuery: '[].{id:id,name:name,type:type,value:value}',
         plugins: parent.plugins,
         options: parent.options,
         url: args => `${parent.url(args)}/networkAcl`,

--- a/bin/generic/service/index.js
+++ b/bin/generic/service/index.js
@@ -43,7 +43,7 @@ module.exports = (parent) => {
 
     const category = Cli.createCategory(resource.name, {
         description: `Manage your services of ${parent.title}`,
-        defaultQuery: '[].{id:_id,name:name,type:type}',
+        defaultQuery: '[].{id:id,name:name,type:type}',
         context: parent.context,
         resource: resource,
     });

--- a/bin/generic/sftp/index.js
+++ b/bin/generic/sftp/index.js
@@ -23,7 +23,7 @@ module.exports = resource => {
             .get(`${resource.url(args)}/${args[resource.name]}`)
             .then(result => {
                 const sshArgs = [
-                    `${result._id}@${result.fqdn}`,
+                    `${result.id}@${result.fqdn}`,
                 ];
 
                 console.log(`sftp ${sshArgs.join(' ')}`);

--- a/bin/generic/ssh/index.js
+++ b/bin/generic/ssh/index.js
@@ -27,7 +27,7 @@ module.exports = resource => {
             .then(resource => {
 
                 const sshArgs = [
-                    `${resource._id}@${resource.fqdn}`,
+                    `${resource.id}@${resource.fqdn}`,
                 ];
 
                 if (args.command) {

--- a/bin/generic/tag/index.js
+++ b/bin/generic/tag/index.js
@@ -17,7 +17,7 @@ module.exports = resource => {
 
     const subresource = {
         name: 'tag',
-        defaultQuery: '[].{id:_id,name:name,type:flavour,state:state,processing:processing}',
+        defaultQuery: '[].{id:id,name:name,type:flavour,state:state,processing:processing}',
         url: () => 'vm',
         plugins: genericDefaults.plugins,
         commands: ['list', 'show'],

--- a/bin/image/disk/index.js
+++ b/bin/image/disk/index.js
@@ -17,7 +17,7 @@ module.exports = resource => Cli.createCommand('disk', {
     options: Object.assign({}, resource.options, options),
     params: resource.params,
     handler: async args => {
-        args.query = '[].{id:disk._id,name:disk.name,type:type,size:size}';
+        args.query = '[].{id:disk.id,name:disk.name,type:type,size:size}';
 
         const image = await args.helpers.api.get(`${resource.url(args)}/${args.image}`);
 

--- a/bin/image/index.js
+++ b/bin/image/index.js
@@ -5,7 +5,7 @@ const genericResource = require('bin/generic');
 
 const resource = {
     name: 'image',
-    defaultQuery: '[].{id:_id,name:name,fileSize:ceil(fileSize),created:createdOn,state:state,tags:join(\',\',keys(tag || `{}`) ) }',
+    defaultQuery: '[].{id:id,name:name,fileSize:ceil(fileSize),created:createdOn,state:state,tags:join(\',\',keys(tag || `{}`) ) }',
     commands: ['show', 'delete', 'rename', 'history', 'tag', 'transfer', 'service', 'access/project'],
     plugins: genericDefaults.plugins,
     url: () => 'image',

--- a/bin/image/list/index.js
+++ b/bin/image/list/index.js
@@ -31,7 +31,7 @@ module.exports = resource => Cli.createCommand('list', {
             .then(images => {
 
                 if (args.recommended && args.output !== 'json') {
-                    args.query = args.query || '[].{id:_id,name:name,distro:description.distro,release:description.release,codename:description.codename,edition:description.edition,arch:description.arch,fileSize:ceil(fileSize),created:createdOn}';
+                    args.query = args.query || '[].{id:id,name:name,distro:description.distro,release:description.release,codename:description.codename,edition:description.edition,arch:description.arch,fileSize:ceil(fileSize),created:createdOn}';
                     images.forEach(image => {
                         image.description = JSON.parse(image.description);
                     });

--- a/bin/image/tests.js
+++ b/bin/image/tests.js
@@ -13,7 +13,7 @@ const getCommon = async (t, options = {}) => {
     return {
         vm, disk_name, vm_name,
         cleanup: async () => {
-            await tests.remove('vm', vm._id);
+            await tests.remove('vm', vm.id);
             await tests.remove('disk', disk_name);
         },
     };
@@ -23,7 +23,7 @@ ava.serial('image life cycle', async t => {
     const common = await getCommon(t);
     try {
         await tests.resourceLifeCycle('image', {
-            createParams: `--vm ${common.vm._id} --name ${tests.getName(t.title)}`,
+            createParams: `--vm ${common.vm.id} --name ${tests.getName(t.title)}`,
             stateCreated: 'Online',
             skipFqdn: true,
         })(t);
@@ -35,7 +35,7 @@ ava.serial('image life cycle', async t => {
 ava.serial('image rename', async t => {
     const common = await getCommon(t);
     try {
-        await tests.resourceRename('image', `--vm ${common.vm._id} --name ${tests.getName(t.title)}`)(t);
+        await tests.resourceRename('image', `--vm ${common.vm.id} --name ${tests.getName(t.title)}`)(t);
     } finally {
         await common.cleanup();
     }
@@ -45,7 +45,7 @@ for (const [name, project] of Object.entries(tests.access_test_case)) {
     ava.serial(`image access: ${name}`, async t => {
         const common = await getCommon(t);
         try {
-            await tests.resourceAccessCycle('image', project, `--vm ${common.vm._id} --name ${tests.getName(t.title)}`)(t);
+            await tests.resourceAccessCycle('image', project, `--vm ${common.vm.id} --name ${tests.getName(t.title)}`)(t);
         } finally {
             await common.cleanup();
         }

--- a/bin/ip/index.js
+++ b/bin/ip/index.js
@@ -5,7 +5,7 @@ const genericResource = require('bin/generic');
 const resource = {
     name: 'ip',
     title: 'IP address',
-    defaultQuery: '[].{id:_id,address:address,mac:mac,ptrRecord:ptrRecord,network:network,fip:associated.fip,state:state,tags:join(\',\',keys(tag || `{}`) ) }',
+    defaultQuery: '[].{id:id,address:address,mac:mac,ptrRecord:ptrRecord,network:network,fip:associated.fip,state:state,tags:join(\',\',keys(tag || `{}`) ) }',
     commands: ['list', 'show', 'delete', 'history', 'tag', 'transfer', 'service'],
 };
 

--- a/bin/ip/tests.js
+++ b/bin/ip/tests.js
@@ -15,7 +15,7 @@ ava.serial('ip life cycle', tests.resourceLifeCycle('ip', {
 
 ava.serial('ip ptr update', async t => {
     const fresh_ip = await tests.run('ip create');
-    const updated_ip = await tests.run(`ip ptr --ip ${fresh_ip._id} --value mail.host.example.com`);
+    const updated_ip = await tests.run(`ip ptr --ip ${fresh_ip.id} --value mail.host.example.com`);
     t.true(updated_ip.ptrRecord === 'mail.host.example.com');
     await tests.remove('ip', updated_ip);
 });
@@ -33,11 +33,11 @@ ava.serial('ip associate & disassociate', async t => {
     const password = await tests.getToken();
 
     const network = await tests.run(`network create --name net-ip-test-${now}`);
-    const vm = await tests.run(`vm create --type a1.nano --no-start --name vm-ip-test-${now} --network ${network._id} --password ${password}`);
-    const nic_list = await tests.run(`vm nic list --vm ${vm._id}`);
+    const vm = await tests.run(`vm create --type a1.nano --no-start --name vm-ip-test-${now} --network ${network.id} --password ${password}`);
+    const nic_list = await tests.run(`vm nic list --vm ${vm.id}`);
     const ip_private = nic_list[0].ip[0];
 
-    const result = await tests.run(`ip associate --ip ${ip.address} --private-ip ${ip_private._id}`);
+    const result = await tests.run(`ip associate --ip ${ip.address} --private-ip ${ip_private.id}`);
 
     t.true(result.state === 'Associated');
 

--- a/bin/iso/create/index.js
+++ b/bin/iso/create/index.js
@@ -59,11 +59,11 @@ module.exports = resource => Cli.createCommand('create', {
                 },
             });
 
-            const ws = await args.helpers.api.wsUpload(`iso/${iso._id}/upload`);
+            const ws = await args.helpers.api.wsUpload(`iso/${iso.id}/upload`);
 
             await websocketStream.upload(ws, args['source-file']);
 
-            iso = await args.helpers.api.get(`${resource.url(args)}/${iso._id}`);
+            iso = await args.helpers.api.get(`${resource.url(args)}/${iso.id}`);
         }
 
         return args.helpers.sendOutput(args, iso);

--- a/bin/iso/index.js
+++ b/bin/iso/index.js
@@ -5,7 +5,7 @@ const genericResource = require('bin/generic');
 
 const resource = {
     name: 'iso',
-    defaultQuery: '[].{id:_id,name:name,size:size,state:state,tags:join(\',\',keys(tag || `{}`) ) }',
+    defaultQuery: '[].{id:id,name:name,size:size,state:state,tags:join(\',\',keys(tag || `{}`) ) }',
     url: () => 'iso',
     plugins: genericDefaults.plugins,
     extraCommands: ['transfer', 'access/project', 'resume'],

--- a/bin/iso/tests.js
+++ b/bin/iso/tests.js
@@ -38,13 +38,13 @@ ava.serial('iso use in vm local uploaded', async t => {
     const secret = await tests.getToken();
 
     const vm = await tests.run(`vm create --name ${tests.getName(t.title)} --type a1.nano --password ${secret} --no-start`);
-    await tests.run(`vm dvd insert --vm ${vm._id} --iso ${iso._id}`);
+    await tests.run(`vm dvd insert --vm ${vm.id} --iso ${iso.id}`);
 
-    await tests.run(`vm start --vm ${vm._id}`);
-    const vm_started = await tests.run(`vm show --vm ${vm._id}`);
+    await tests.run(`vm start --vm ${vm.id}`);
+    const vm_started = await tests.run(`vm show --vm ${vm.id}`);
 
     t.true(vm_started.state === 'Running');
-    await tests.run(`vm dvd eject --yes --vm ${vm._id}`);
+    await tests.run(`vm dvd eject --yes --vm ${vm.id}`);
 
     await tests.remove('iso', iso);
     await tests.remove('vm', vm);

--- a/bin/log/index.js
+++ b/bin/log/index.js
@@ -31,7 +31,7 @@ const schema = {
 const resource = {
     name: 'log',
     apiName: 'logArchive',
-    defaultQuery: '[].{id:_id,name:name,retention:retention,sizeUsed:sizeUsed,state:state,processing:processing}',
+    defaultQuery: '[].{id:id,name:name,retention:retention,sizeUsed:sizeUsed,state:state,processing:processing}',
     commands: ['show', 'delete', 'rename', 'create', 'list', 'history', 'tag', 'service', 'transfer', 'credential'],
     plugins: genericDefaults.plugins,
     url: () => 'logArchive',

--- a/bin/log/tests.js
+++ b/bin/log/tests.js
@@ -24,12 +24,12 @@ ava.serial('log logger & stream', async t => {
     const log_file = tests.getRandomFile(content);
     const output_file = tests.randomFileName();
     const log = await tests.run(`log create --name log-logger-${now}`);
-    await tests.run(`log credential password add --log ${log._id} --name my-token --password ${token}`);
-    await tests.run(`log logger --log ${log._id} --token ${token} --log-file ${log_file}`);
+    await tests.run(`log credential password add --log ${log.id} --name my-token --password ${token}`);
+    await tests.run(`log logger --log ${log.id} --token ${token} --log-file ${log_file}`);
     let log_content;
     for (let i = 0; i <= 3; i++) {
         await tests.delay(1000); // to receive message
-        await tests.run(`log stream --log ${log._id} --jsonl-file ${output_file}`);
+        await tests.run(`log stream --log ${log.id} --jsonl-file ${output_file}`);
         log_content = fs.readFileSync(output_file, 'utf-8');
         if (log_content) {
             break;

--- a/bin/netgw/index.js
+++ b/bin/netgw/index.js
@@ -23,7 +23,7 @@ const schema = {
 };
 const resource = {
     name: 'netgw',
-    defaultQuery: '[].{id:_id,name:name,IP:primaryIP,network:network, tags:join(\',\',keys(tag || `{}`) ) }',
+    defaultQuery: '[].{id:id,name:name,IP:primaryIP,network:network, tags:join(\',\',keys(tag || `{}`) ) }',
     url: () => 'netgw',
     title: 'Network gateway',
     schema,

--- a/bin/netgw/tests.js
+++ b/bin/netgw/tests.js
@@ -9,7 +9,7 @@ const now = Date.now();
 ava.serial('netgw life cycle', async t => {
     const ip = await tests.run('ip create');
     await tests.resourceLifeCycle('netgw', {
-        createParams: `--name netgw-test-${now} --ip ${ip._id}`,
+        createParams: `--name netgw-test-${now} --ip ${ip.id}`,
         stateCreated: 'Detached',
         skipFqdn: true,
         skipTransfer: true,
@@ -19,21 +19,21 @@ ava.serial('netgw life cycle', async t => {
 
 ava.serial('netgw rename', async t => {
     const ip = await tests.run('ip create');
-    await tests.resourceRename('netgw', `--name netgw-test-${now} --ip ${ip._id}`)(t);
+    await tests.resourceRename('netgw', `--name netgw-test-${now} --ip ${ip.id}`)(t);
     await tests.remove('ip', ip);
 });
 
 ava.serial('netgw attach & detach', async t => {
     const ip = await tests.run('ip create');
     const network = await tests.run(`network create --name netgw-test-${now}`);
-    const netgw = await tests.run(`netgw create --name netgw-test-${now} --ip ${ip._id}`);
+    const netgw = await tests.run(`netgw create --name netgw-test-${now} --ip ${ip.id}`);
 
-    await tests.run(`netgw attach --netgw ${netgw._id} --network ${network._id}`);
+    await tests.run(`netgw attach --netgw ${netgw.id} --network ${network.id}`);
 
-    const attached_netgw = await tests.run(`netgw show --netgw ${netgw._id}`);
-    t.true(attached_netgw.network === network._id);
+    const attached_netgw = await tests.run(`netgw show --netgw ${netgw.id}`);
+    t.true(attached_netgw.network === network.id);
 
-    await tests.run(`netgw detach --netgw ${netgw._id}`);
+    await tests.run(`netgw detach --netgw ${netgw.id}`);
 
     await tests.remove('netgw', netgw);
     await tests.remove('network', network);

--- a/bin/network/index.js
+++ b/bin/network/index.js
@@ -4,7 +4,7 @@ const genericResource = require('bin/generic');
 
 const resource = {
     name: 'network',
-    defaultQuery: '[].{id:_id,name:name,type:type,firewall:firewall,address:address,tags:join(\',\',keys(tag || `{}`) ) }',
+    defaultQuery: '[].{id:id,name:name,type:type,firewall:firewall,address:address,tags:join(\',\',keys(tag || `{}`) ) }',
     title: 'Network',
     extraCommands: ['firewall'],
 };

--- a/bin/network/tests.js
+++ b/bin/network/tests.js
@@ -17,13 +17,13 @@ ava.serial('network rename', tests.resourceRename('network', `--name network-tes
 ava.serial('network ip life cycle', async t => {
     const network = await tests.run(`network create --name network-test-${now}`);
     await tests.resourceLifeCycle('network ip', {
-        createParams: `--network ${network._id}`,
-        listParams: `--network ${network._id}`,
-        showParams: `--network ${network._id}`,
-        deleteParams: `--network ${network._id}`,
-        tagParams: `--network ${network._id}`,
-        serviceListParams: `--network ${network._id}`,
-        serviceShowParams: `--network ${network._id}`,
+        createParams: `--network ${network.id}`,
+        listParams: `--network ${network.id}`,
+        showParams: `--network ${network.id}`,
+        deleteParams: `--network ${network.id}`,
+        tagParams: `--network ${network.id}`,
+        serviceListParams: `--network ${network.id}`,
+        serviceShowParams: `--network ${network.id}`,
         skipHistory: true,
         stateCreated: 'Unallocated',
         schemaRef: '#/components/schemas/ip',
@@ -51,8 +51,8 @@ ava.serial('network firewall', async t => {
     const firewall = await tests.run(`firewall create --name ${tests.getName(t.title)}`);
 
     await tests.run(`network firewall add --firewall ${firewall.name} --network ${network.name}`);
-    const network_with_firewall = await tests.run(`network show --network ${network._id}`);
-    t.true(network_with_firewall.firewall === firewall._id);
+    const network_with_firewall = await tests.run(`network show --network ${network.id}`);
+    t.true(network_with_firewall.firewall === firewall.id);
 
     await tests.run(`network firewall remove --network ${network.name}`);
 

--- a/bin/organisation/index.js
+++ b/bin/organisation/index.js
@@ -4,7 +4,7 @@ const genericResource = require('bin/generic');
 
 const resource = {
     name: 'organisation',
-    defaultQuery: '[].{id:_id,name:name,billing:billing.company,active:active,tags:join(\',\',keys(tag || `{}`) ) }',
+    defaultQuery: '[].{id:id,name:name,billing:billing.company,active:active,tags:join(\',\',keys(tag || `{}`) ) }',
     url: () => 'organisation',
     plugins: [
         require('bin/_plugins/loginRequired'),

--- a/bin/organisation/tests.js
+++ b/bin/organisation/tests.js
@@ -5,7 +5,7 @@ require('../../scope/h1');
 const tests = require('../../lib/tests');
 const config = require('lib/config');
 
-const active_project = config.get('profile.project._id');
+const active_project = config.get('profile.project.id');
 
 ava.serial('organisation life cycle', async t => {
     const project = await tests.run(`project show --project ${active_project}`);

--- a/bin/organisation/transfer/index.js
+++ b/bin/organisation/transfer/index.js
@@ -7,7 +7,7 @@ module.exports = parent => {
     const resource = {
         name: 'transfer',
         description: `Manage your transfer for ${parent.title}`,
-        defaultQuery: '[].{id:_id,name:name}',
+        defaultQuery: '[].{id:id,name:name}',
         url: args => `${parent.url(args)}/transfer`,
         params: parent.params,
         options: parent.options,

--- a/bin/project/index.js
+++ b/bin/project/index.js
@@ -26,7 +26,7 @@ const schema = {
 
 const resource = {
     name: 'project',
-    defaultQuery: '[].{id:_id,name:name,tags:join(\',\',keys(tag || `{}`) ), active: active, organisation:organisation }',
+    defaultQuery: '[].{id:id,name:name,tags:join(\',\',keys(tag || `{}`) ), active: active, organisation:organisation }',
     url: () => 'project',
     plugins: [
         require('bin/_plugins/loginRequired'),

--- a/bin/project/select/index.js
+++ b/bin/project/select/index.js
@@ -17,8 +17,8 @@ module.exports = resource => Cli.createCommand('select', {
     handler: args => args.helpers.api
         .get(resource.url(args))
         .then(project => {
-            config.set('profile.project', { _id: project._id, name: project.name });
-            logger('info', `Project selected: ${project._id} "${project.name}"`);
+            config.set('profile.project', { id: project.id, name: project.name });
+            logger('info', `Project selected: ${project.id} "${project.name}"`);
             return project;
         }).then(result => args.helpers.sendOutput(args, result)),
 });

--- a/bin/project/tests.js
+++ b/bin/project/tests.js
@@ -7,7 +7,7 @@ require('../../scope/h1');
 const tests = require('../../lib/tests');
 const config = require('lib/config');
 
-const active_project = config.get('profile.project._id');
+const active_project = config.get('profile.project.id');
 
 ava.serial('project life cycle', async t => {
     const project = await tests.run(`project show --project ${active_project}`);
@@ -27,7 +27,7 @@ ava.serial('project life cycle', async t => {
 
 ava.serial('project show', async t => {
     const project = await tests.run(`project show --project ${active_project}`);
-    t.true(project._id === active_project);
+    t.true(project.id === active_project);
 });
 
 const getOrganisationForProject = async projectId => (await tests.run(`project show --project '${projectId}'`)).organisation;
@@ -44,15 +44,15 @@ ava.skip('project transfer', tests.requireSlaveProject(async (t, projects) => {
 
     const project = await tests.run(`project create --name ${tests.getName('project-transfer')} --organisation ${active_organisation}`);
 
-    await tests.run(`project transfer --project ${project._id} --organisation ${slave_organisation}`);
+    await tests.run(`project transfer --project ${project.id} --organisation ${slave_organisation}`);
     const transfer_list = await tests.run(`organisation transfer list --organisation ${slave_organisation}`);
-    t.true(transfer_list.some(x => x._id === project._id));
+    t.true(transfer_list.some(x => x.id === project.id));
 
     const payment_list = await tests.run(`organisation payment list --organisation ${slave_organisation}`);
     const free_payment = payment_list.find(x => !x.project);
     t.true(!!free_payment, `No free payment on organization ${slave_organisation}`);
-    await tests.run(`organisation transfer accept --organisation ${slave_organisation} --project ${project._id} --payment ${free_payment._id}`);
-    const transfered_project = await tests.run(`project show --project ${project._id}`);
+    await tests.run(`organisation transfer accept --organisation ${slave_organisation} --project ${project.id} --payment ${free_payment.id}`);
+    const transfered_project = await tests.run(`project show --project ${project.id}`);
     t.true(transfered_project.organisation === slave_organisation);
 
     await tests.remove('project', project);
@@ -64,7 +64,7 @@ ava.serial('project rename', async t => {
     await tests.run(`project rename --project '${active_project}' --new-name '${name}'`);
 
     const project = await tests.run(`project show --project ${active_project}`);
-    t.true(project._id === active_project);
+    t.true(project.id === active_project);
     t.true(project.name === name);
 });
 
@@ -236,10 +236,10 @@ ava.serial('project notification credits integration test', async t => {
 
 ava.serial('project token access life cycle', async t => {
     const token = await tests.run(`project token add --project ${active_project} --name ${tests.getName(t.title)}`);
-    const access = await tests.run(`project token access add --project ${active_project} --method POST --path 'vault/' --token ${token._id}`);
+    const access = await tests.run(`project token access add --project ${active_project} --method POST --path 'vault/' --token ${token.id}`);
 
     await tests.subresourceLifeCycle({
-        resourceId: token._id,
+        resourceId: token.id,
         resourceType: 'project token',
         type: 'access',
         skipRename: true,
@@ -247,7 +247,7 @@ ava.serial('project token access life cycle', async t => {
     })(t);
 
     await tests.remove('project token access', access, {
-        deleteParams: `--project ${active_project} --token ${token._id}`,
+        deleteParams: `--project ${active_project} --token ${token.id}`,
     });
 
     await tests.remove('project token', token);
@@ -255,9 +255,9 @@ ava.serial('project token access life cycle', async t => {
 
 ava.serial('project token env', async t => {
     const token = await tests.run(`project token add --project ${active_project} --name ${tests.getName(t.title)}`);
-    await tests.run(`project token access add --project ${active_project} --method ALL --path '/' --token ${token._id}`);
+    await tests.run(`project token access add --project ${active_project} --method ALL --path '/' --token ${token.id}`);
 
-    const content = await tests.run(`project token env --project ${active_project} --token ${token._id} `);
+    const content = await tests.run(`project token env --project ${active_project} --token ${token.id} `);
     t.true(content.includes('_PROJECT'));
     t.true(content.includes('_ACCESS_TOKEN_ID'));
     t.true(content.includes('_ACCESS_TOKEN_SECRET'));
@@ -270,17 +270,17 @@ ava.serial('token was used if environment variable set', async t => {
     const token = await tests.run(`project token add --name ${tests.getName('token-validates')} --project ${active_project}`);
 
     // Clean up default access
-    const access_list = await tests.run(`project token access list --project ${active_project} --token ${token._id}`);
+    const access_list = await tests.run(`project token access list --project ${active_project} --token ${token.id}`);
     for (const access of access_list) {
-        await tests.run(`project token access delete --token ${token._id} --access ${access._id} --yes`);
+        await tests.run(`project token access delete --token ${token.id} --access ${access.id} --yes`);
     }
 
-    await tests.run(`project token access add --token ${token._id} --method GET --path '/vm'`);
+    await tests.run(`project token access add --token ${token.id} --method GET --path '/vm'`);
 
     await t.throwsAsync(() => tests.run({
         cmd: 'disk list',
         env: {
-            HYPERONE_ACCESS_TOKEN_SECRET: token._id,
+            HYPERONE_ACCESS_TOKEN_SECRET: token.id,
         },
     }));
 
@@ -298,7 +298,7 @@ ava.serial('project select', tests.requireSlaveProject(async (t, projects) => {
     await tests.run(`project select --project '${projects.slave}'`);
     const ip_list = await tests.run('ip list');
     await tests.run(`project select --project '${projects.master}'`);
-    t.true(!ip_list.some(ip => ip._id === new_ip._id));
+    t.true(!ip_list.some(ip => ip.id === new_ip.id));
     await tests.remove('ip', new_ip);
 }));
 

--- a/bin/project/token/access/index.js
+++ b/bin/project/token/access/index.js
@@ -8,7 +8,7 @@ module.exports = parent => {
         name: 'access',
         plugins: parent.plugins,
         description: `Manage your ${parent.name} access`,
-        defaultQuery: '[].{id:_id,method:method,path:path}',
+        defaultQuery: '[].{id:id,method:method,path:path}',
         url: args => `${parent.url(args)}/access`,
         params: parent.params,
         options: parent.options,

--- a/bin/project/token/env/index.js
+++ b/bin/project/token/env/index.js
@@ -41,8 +41,8 @@ module.exports = resource => Cli.createCommand('env', {
             }
             return [
                 shellView(`${process.env.SCOPE_FULL_NAME.toUpperCase()}_PROJECT`, args.project),
-                shellView(`${process.env.SCOPE_FULL_NAME.toUpperCase()}_ACCESS_TOKEN_ID`, token._id),
-                shellView(`${process.env.SCOPE_FULL_NAME.toUpperCase()}_ACCESS_TOKEN_SECRET`, token.secret || token._id),
+                shellView(`${process.env.SCOPE_FULL_NAME.toUpperCase()}_ACCESS_TOKEN_ID`, token.id),
+                shellView(`${process.env.SCOPE_FULL_NAME.toUpperCase()}_ACCESS_TOKEN_SECRET`, token.secret || token.id),
             ].join('\n');
         }),
 });

--- a/bin/project/token/index.js
+++ b/bin/project/token/index.js
@@ -7,7 +7,7 @@ module.exports = parent => {
     const resource = {
         name: 'token',
         description: `Manage your ${parent.title} tokens`,
-        defaultQuery: '[].{id:_id,name:name,createdOn:createdOn,createdBy:createdBy}',
+        defaultQuery: '[].{id:id,name:name,createdOn:createdOn,createdBy:createdBy}',
         url: args => `${parent.url(args)}/credential/authtoken`,
         params: parent.params,
         options: parent.options,

--- a/bin/registry/index.js
+++ b/bin/registry/index.js
@@ -39,7 +39,7 @@ const schema = {
 
 const resource = {
     name: 'registry',
-    defaultQuery: '[].{id:_id,name:name,service:flavour,size:sizeUsed,created:createdOn,state:state,tags:join(\',\',keys(tag || `{}`) ) }',
+    defaultQuery: '[].{id:id,name:name,service:flavour,size:sizeUsed,created:createdOn,state:state,tags:join(\',\',keys(tag || `{}`) ) }',
     url: () => 'registry',
     plugins: genericDefaults.plugins,
     extraCommands: ['create', 'start', 'stop', 'transfer', 'update', 'credential'],

--- a/bin/replica/disk/index.js
+++ b/bin/replica/disk/index.js
@@ -15,7 +15,7 @@ module.exports = resource => {
     const subresource = {
         title: `Disk of ${resource.title}`,
         name: 'disk',
-        defaultQuery: '[].{id:disk._id, location: _id, size:disk.size, type:disk.type}',
+        defaultQuery: '[].{id:disk.id, location: _id, size:disk.size, type:disk.type}',
         url: args => `${resource.url(args)}/${args.replica}/hdd`,
         commands: ['list'],
         options: options,

--- a/bin/replica/disk/index.js
+++ b/bin/replica/disk/index.js
@@ -15,7 +15,7 @@ module.exports = resource => {
     const subresource = {
         title: `Disk of ${resource.title}`,
         name: 'disk',
-        defaultQuery: '[].{id:disk.id, location: _id, size:disk.size, type:disk.type}',
+        defaultQuery: '[].{id:disk.id, location: id, size:disk.size, type:disk.type}',
         url: args => `${resource.url(args)}/${args.replica}/hdd`,
         commands: ['list'],
         options: options,

--- a/bin/replica/index.js
+++ b/bin/replica/index.js
@@ -6,7 +6,7 @@ const genericResource = require('bin/generic');
 const resource = {
     name: 'replica',
     title: 'Replica',
-    defaultQuery: '[].{id:_id, name:name, state:state, tags:join(\',\',keys(tag || `{}`) )}',
+    defaultQuery: '[].{id:id, name:name, state:state, tags:join(\',\',keys(tag || `{}`) )}',
     url: () => 'replica',
     plugins: genericDefaults.plugins,
 };

--- a/bin/reservation/index.js
+++ b/bin/reservation/index.js
@@ -26,7 +26,7 @@ const schema = {
 
 const resource = {
     name: 'reservation',
-    defaultQuery: '[].{id:_id,name:name,state:state,resource:resource,type:flavour,assigned:assigned}',
+    defaultQuery: '[].{id:id,name:name,state:state,resource:resource,type:flavour,assigned:assigned}',
     url: () => 'reservation',
     plugins: genericDefaults.plugins,
     commands: [ 'list', 'show', 'service', 'create', 'tag', 'history', 'delete'],

--- a/bin/reservation/tests.js
+++ b/bin/reservation/tests.js
@@ -23,7 +23,7 @@ ava.skip('reservation assign limits', async t => {
     const reservation = await tests.run(`reservation create --name ${tests.getName(t.title)} --type '${reservation_flavour}'`);
 
     const reversation_list = await tests.run('reservation list');
-    t.true(reversation_list.some(x => x._id === reservation._id));
+    t.true(reversation_list.some(x => x.id === reservation.id));
     const token = await tests.getToken();
 
     const common_vm_params = `--type ${vm_flavour} --no-start --password ${token}`;
@@ -31,12 +31,12 @@ ava.skip('reservation assign limits', async t => {
     const vm_valid = await tests.run(`vm create --name ${tests.getName(t.title, 'vm valid')} ${common_vm_params} `);
     const vm_over_limit = await tests.run(`vm create --name ${tests.getName(t.title, 'vm wrong type')} ${common_vm_params}`);
     await tests.delay(4 * 60 * 1000);
-    await tests.run(`reservation assign --reservation ${reservation.name} --resource ${vm_valid._id}`);
-    await t.throwsAsync(() => tests.run(`reservation assign --reservation ${reservation.name} --resource ${vm_over_limit._id}`));
-    await t.throwsAsync(() => tests.run(`reservation assign --reservation ${reservation.name} --resource ${vm_wrong_type._id}`));
+    await tests.run(`reservation assign --reservation ${reservation.name} --resource ${vm_valid.id}`);
+    await t.throwsAsync(() => tests.run(`reservation assign --reservation ${reservation.name} --resource ${vm_over_limit.id}`));
+    await t.throwsAsync(() => tests.run(`reservation assign --reservation ${reservation.name} --resource ${vm_wrong_type.id}`));
 
-    const assigned = await tests.run(`reservation show --reservation ${reservation._id}`);
-    t.true(assigned.assigned === vm_valid._id);
+    const assigned = await tests.run(`reservation show --reservation ${reservation.id}`);
+    t.true(assigned.assigned === vm_valid.id);
     t.true(assigned.state === 'Attached');
 
     await tests.remove('vm', vm_valid);

--- a/bin/service/index.js
+++ b/bin/service/index.js
@@ -6,7 +6,7 @@ const genericResource = require('bin/generic');
 const resource = {
     name: 'service',
     description: 'Explore available services',
-    defaultQuery: '[].{id:_id,resource:resource,type:type,name:name, PLN:billing.price.PLN, period:billing.period}',
+    defaultQuery: '[].{id:id,resource:resource,type:type,name:name, PLN:billing.price.PLN, period:billing.period}',
     plugins: genericDefaults.plugins,
     url: () => 'service',
     commands: [ 'show' ],

--- a/bin/service/tests.js
+++ b/bin/service/tests.js
@@ -11,7 +11,7 @@ ava.serial('service all', async t => {
     const service = await tests.show('service', list[0]);
 
     t.true(service.name === list[0].name);
-    t.true(service._id === list[0]._id);
+    t.true(service.id === list[0].id);
 });
 
 ava.serial('service project', async t => {

--- a/bin/snapshot/index.js
+++ b/bin/snapshot/index.js
@@ -24,7 +24,7 @@ const schema = {
 
 const resource = {
     name: 'snapshot',
-    defaultQuery: '[].{id:_id,name:name,size:sizeUsed,state:state,tags:join(\',\',keys(tag || `{}`) ) }',
+    defaultQuery: '[].{id:id,name:name,size:sizeUsed,state:state,tags:join(\',\',keys(tag || `{}`) ) }',
     url: () => 'snapshot',
     extraCommands: ['create'],
     dirname: __dirname,

--- a/bin/snapshot/tests.js
+++ b/bin/snapshot/tests.js
@@ -13,7 +13,7 @@ ava.serial('snapshot life cycle', async t => {
     const name = `snapshot-test-${now}`;
 
     await tests.resourceLifeCycle('snapshot', {
-        createParams: `--vault ${vault._id} --name ${name}`,
+        createParams: `--vault ${vault.id} --name ${name}`,
         stateCreated: 'Online',
         skipTransfer: true,
         skipFqdn: true,
@@ -28,7 +28,7 @@ ava.serial('snapshot rename', async t => {
     const name = `snapshot-test-${now}`;
 
     await tests.resourceRename('snapshot', {
-        createParams: `--vault ${vault._id} --name ${name}`,
+        createParams: `--vault ${vault.id} --name ${name}`,
     })(t);
 
     await tests.remove('vault', vault);

--- a/bin/user/2fa/disable/index.js
+++ b/bin/user/2fa/disable/index.js
@@ -17,7 +17,7 @@ module.exports = resource => Cli.createCommand('disable', {
         const password = passwords.find(p => p.type === args.type);
 
         if (password) {
-            await args.helpers.api.delete(`${args.$node.parent.config.url(args)}/${password._id}`);
+            await args.helpers.api.delete(`${args.$node.parent.config.url(args)}/${password.id}`);
             console.log('Done');
         } else {
             console.log(`${args.type} not found`);

--- a/bin/user/2fa/index.js
+++ b/bin/user/2fa/index.js
@@ -9,7 +9,7 @@ module.exports = resource => {
     const category = Cli.createCategory('2fa', {
         description: 'Manage two factor authentication',
         url: () => 'user/me/credential/password',
-        defaultQuery: '[].{id: _id, type: type, name: name, createdOn: createdOn}',
+        defaultQuery: '[].{id: id, type: type, name: name, createdOn: createdOn}',
     });
 
     category.addChild(require('./enable')(resource));

--- a/bin/vault/console/index.js
+++ b/bin/vault/console/index.js
@@ -3,5 +3,5 @@
 const genericConsole = require('bin/generic/console');
 
 module.exports = resource => genericConsole(resource,
-    (args, vault) => `https://panel.hyperone.com/console/vault/${vault._id}?project=${args.profile.project._id}&scope=${process.env.SCOPE_NAME}`
+    (args, vault) => `https://panel.hyperone.com/console/vault/${vault.id}?project=${args.profile.project.id}&scope=${process.env.SCOPE_NAME}`
 );

--- a/bin/vault/index.js
+++ b/bin/vault/index.js
@@ -35,7 +35,7 @@ const schema = {
 
 const resource = {
     name: 'vault',
-    defaultQuery: '[].{id:_id,name:name,size:size,state:state,tags:join(\',\',keys(tag || `{}`) ) }',
+    defaultQuery: '[].{id:id,name:name,size:size,state:state,tags:join(\',\',keys(tag || `{}`) ) }',
     url: () => 'vault',
     plugins: genericDefaults.plugins,
     extraCommands: ['resize', 'ssh', 'sftp', 'start', 'stop', 'credential'],

--- a/bin/vault/tests.js
+++ b/bin/vault/tests.js
@@ -46,12 +46,12 @@ ava.serial('vault rename', async t => {
 ava.serial('vault stop & start', async t => {
     const vault = await tests.run(`vault create --name ${tests.getName(t.title)} --size 10`);
 
-    await tests.run(`vault stop --vault ${vault._id}`);
-    const vault_stopped = await tests.run(`vault show --vault ${vault._id}`);
+    await tests.run(`vault stop --vault ${vault.id}`);
+    const vault_stopped = await tests.run(`vault show --vault ${vault.id}`);
     t.true(vault_stopped.state === 'Off');
 
-    await tests.run(`vault start --vault ${vault._id}`);
-    const vault_started = await tests.run(`vault show --vault ${vault._id}`);
+    await tests.run(`vault start --vault ${vault.id}`);
+    const vault_started = await tests.run(`vault show --vault ${vault.id}`);
     t.true(vault_started.state === 'Online');
 
     await tests.remove('vault', vault);
@@ -67,11 +67,11 @@ ava.serial('vault credential credentials life cycle', async t => {
     const vault = await tests.run(`vault create --name ${tests.getName(t.title)} --size 10`);
 
     await tests.credentialsLifeCycle('vault credential cert', {
-        showParams: `--vault ${vault._id}`,
-        createParams: `--vault ${vault._id}`,
-        listParams: `--vault ${vault._id}`,
-        deleteParams: `--vault ${vault._id}`,
-        renameParams: `--vault ${vault._id}`,
+        showParams: `--vault ${vault.id}`,
+        createParams: `--vault ${vault.id}`,
+        listParams: `--vault ${vault.id}`,
+        deleteParams: `--vault ${vault.id}`,
+        renameParams: `--vault ${vault.id}`,
     })(t);
 
     await tests.remove('vault', vault);
@@ -85,7 +85,7 @@ ava.serial('vault recreate from snapshot', async t => {
     const filename = `my-secret-file-${now}.txt`;
     await ssh.execResource(vault, {password}, `touch ~/${filename}`);
 
-    const snapshot = await tests.run(`snapshot create --vault ${vault._id} --name snapshot-${name}`);
+    const snapshot = await tests.run(`snapshot create --vault ${vault.id} --name snapshot-${name}`);
 
     const recreated_vault = await tests.run(`vault create --name ${name} --size 10 --snapshot ${snapshot.name} --password ${password}`);
     t.true(recreated_vault.created);
@@ -113,7 +113,7 @@ ava.serial('vault credential password life cycle', async t => {
         const credentials = await tests.run(`${type} credentials add --name ${ssh_name} --sshkey-file '${ssh_file}'`);
         const vault = await tests.run(`vault create --name my-vault --size 10 --ssh ${ssh_name}`);
 
-        const list = await tests.run(`vault credential cert list --vault ${vault._id}`);
+        const list = await tests.run(`vault credential cert list --vault ${vault.id}`);
         t.true(list.some(p => p.name === ssh_name));
 
         await tests.remove(`${type} credentials`, credentials);

--- a/bin/vm/console/index.js
+++ b/bin/vm/console/index.js
@@ -3,5 +3,5 @@
 const genericConsole = require('bin/generic/console');
 
 module.exports = resource => genericConsole(resource,
-    (args, vm) => `https://console.hyperone.com/console/#/?scope=h1&username=${vm._id}&password=${args.apiKey}&billingTenant=${args.profile.project._id}`
+    (args, vm) => `https://console.hyperone.com/console/#/?scope=h1&username=${vm.id}&password=${args.apiKey}&billingTenant=${args.profile.project.id}`
 );

--- a/bin/vm/disk/index.js
+++ b/bin/vm/disk/index.js
@@ -14,7 +14,7 @@ const options = {
 
 const resource = {
     name: 'disk',
-    defaultQuery: '[].{id:_id,iops:maximumIOPS,diskname:disk.name,diskId:disk._id,diskName:disk.name,diskType:disk.type,diskSize:disk.size}',
+    defaultQuery: '[].{id:id,iops:maximumIOPS,diskname:disk.name,diskId:disk.id,diskName:disk.name,diskType:disk.type,diskSize:disk.size}',
     url: args => `vm/${args.vm}/hdd`,
     options: options,
     commands: ['list'],

--- a/bin/vm/dvd/index.js
+++ b/bin/vm/dvd/index.js
@@ -13,7 +13,7 @@ const options = {
 
 const resource = {
     name: 'dvd',
-    defaultQuery: '[].{id:_id,iso:iso._id,isoname:iso.name}',
+    defaultQuery: '[].{id:id,iso:iso.id,isoname:iso.name}',
     url: args => `vm/${args.vm}/dvddrive`,
     commands: ['list'],
     plugins: genericDefaults.plugins,

--- a/bin/vm/index.js
+++ b/bin/vm/index.js
@@ -7,7 +7,7 @@ const text = require('lib/text');
 
 const resource = {
     name: 'vm',
-    defaultQuery: '[].{id:_id,name:name,type:flavour,state:state,tags:join(\',\',keys(tag || `{}`) ) }',
+    defaultQuery: '[].{id:id,name:name,type:flavour,state:state,tags:join(\',\',keys(tag || `{}`) ) }',
     url: () => 'vm',
     plugins: genericDefaults.plugins,
     commands: [ 'list', 'show', 'history', 'tag', 'service'],

--- a/bin/vm/metrics/index.js
+++ b/bin/vm/metrics/index.js
@@ -16,7 +16,7 @@ const logMetrics = (type, resource, ws, callback) => ws.on('message', message =>
 });
 
 const combineMetrics = async (api, type, resource, all) => {
-    const ws = await api.wsMetrics(`${type}/${resource._id}/metrics`);
+    const ws = await api.wsMetrics(`${type}/${resource.id}/metrics`);
     all[type] = all[type] || [];
 
     const obj = {

--- a/bin/vm/nic/index.js
+++ b/bin/vm/nic/index.js
@@ -14,7 +14,7 @@ const options = {
 const resource = {
     name: 'nic',
     // eslint-disable-next-line quotes
-    defaultQuery: "[].{id:_id,mac:macaddress,speed:speed,firewall:firewall,ipaddress:join(',',ip[].address),tags:join(',',keys(tag || `{}`) )}",
+    defaultQuery: "[].{id:id,mac:macaddress,speed:speed,firewall:firewall,ipaddress:join(',',ip[].address),tags:join(',',keys(tag || `{}`) )}",
     url: args => `vm/${args.vm}/netadp`,
     options: options,
     plugins: defaults.plugins,

--- a/bin/vm/nic/ip/index.js
+++ b/bin/vm/nic/ip/index.js
@@ -14,7 +14,7 @@ module.exports = (parent) => {
 
     const resource = {
         name: 'ip',
-        defaultQuery: '[].{id:_id,address:address,mac:mac,ptrRecord:ptrRecord,network:network,fip:associated.fip,state:state}',
+        defaultQuery: '[].{id:id,address:address,mac:mac,ptrRecord:ptrRecord,network:network,fip:associated.fip,state:state}',
         url: args => `${parent.url(args)}/${args[parent.name]}/ip`,
         plugins: defaults.plugins,
         options: Object.assign({}, parent.options, options),

--- a/bin/vm/serialport/console/index.js
+++ b/bin/vm/serialport/console/index.js
@@ -23,7 +23,7 @@ module.exports = resource => Cli.createCommand('console', {
     options: Object.assign({}, options, resource.options),
     dirname: __dirname,
     handler: args => args.helpers.api.get(`vm/${args.vm}`)
-        .then(vm => websocketTerminal(`/vm/${vm._id}/serialport/${args.port}`)),
+        .then(vm => websocketTerminal(`/vm/${vm.id}/serialport/${args.port}`)),
 });
 
 

--- a/bin/vm/tests.js
+++ b/bin/vm/tests.js
@@ -62,9 +62,9 @@ ava.serial('vm stop & start & turnoff', async t => {
     ];
 
     for (const action of actions) {
-        const action_vm = await tests.run(`vm ${action.name} --vm ${vm._id}`);
+        const action_vm = await tests.run(`vm ${action.name} --vm ${vm.id}`);
         t.true(action_vm.state === action.state);
-        const updated_vm = await tests.run(`vm show --vm ${vm._id}`);
+        const updated_vm = await tests.run(`vm show --vm ${vm.id}`);
         t.true(updated_vm.state === action.state);
     }
 
@@ -78,9 +78,9 @@ ava.serial('vm userdata', async t => {
     const common = await getCommon(t.title);
     const vm = await tests.run(`vm create ${common.params.createParams}`);
 
-    await tests.run(`vm userdata --vm ${vm._id} --userdata-file '${tmp_file}'`);
+    await tests.run(`vm userdata --vm ${vm.id} --userdata-file '${tmp_file}'`);
 
-    const userdata_vm = await tests.run(`vm show --vm ${vm._id}`);
+    const userdata_vm = await tests.run(`vm show --vm ${vm.id}`);
     const userdata_text = Buffer.from(userdata_vm.userMetadata, 'base64').toString('ascii');
 
     t.true(userdata_text === my_metadata);
@@ -115,9 +115,9 @@ ava.serial('vm disk attach & detach', async t => {
     ];
 
     for (const action of actions) {
-        await tests.run(`vm disk ${action.name} --vm ${vm._id} --disk ${disk._id}`);
-        const list = await tests.run(`vm disk list --vm ${vm._id}`);
-        t.true(list.some(x => x.disk._id === disk._id) === action.result);
+        await tests.run(`vm disk ${action.name} --vm ${vm.id} --disk ${disk.id}`);
+        const list = await tests.run(`vm disk list --vm ${vm.id}`);
+        t.true(list.some(x => x.disk.id === disk.id) === action.result);
     }
 
     await common.cleanup();
@@ -133,12 +133,12 @@ ava.serial('vm nic life cycle', async t => {
 
     await tests.resourceLifeCycle('vm nic', {
         stateCreated: 'Online',
-        createParams: `--vm ${vm._id} --type private --network ${network._id}`,
-        listParams: `--vm ${vm._id}`,
-        showParams: `--vm ${vm._id}`,
-        tagParams: `--vm ${vm._id}`,
-        deleteParams: `--vm ${vm._id}`,
-        historyParams: `--vm ${vm._id}`,
+        createParams: `--vm ${vm.id} --type private --network ${network.id}`,
+        listParams: `--vm ${vm.id}`,
+        showParams: `--vm ${vm.id}`,
+        tagParams: `--vm ${vm.id}`,
+        deleteParams: `--vm ${vm.id}`,
+        historyParams: `--vm ${vm.id}`,
         skipService: true,
         skipFqdn: true,
         skipTransfer: true,
@@ -156,13 +156,13 @@ ava.serial('vm nic firewall life cycle', async t => {
     const firewall = await tests.run(`firewall create --name ${tests.getName(t.title)}`);
     const network = await tests.run(`network create --name ${tests.getName(t.title)}`);
     const vm = await tests.run(`vm create --no-start ${common.params.createParams}`);
-    const nic_list = await tests.run(`vm nic list --vm ${vm._id}`);
+    const nic_list = await tests.run(`vm nic list --vm ${vm.id}`);
     const nic = nic_list[0];
-    await tests.run(`vm nic firewall add --vm ${vm.name} --nic ${nic._id} --firewall ${firewall.name} `);
+    await tests.run(`vm nic firewall add --vm ${vm.name} --nic ${nic.id} --firewall ${firewall.name} `);
 
-    const nic_with_firewall = await tests.run(`vm nic show --vm ${vm._id} --nic ${nic._id}`);
-    t.true(nic_with_firewall.firewall === firewall._id);
-    await tests.run(`vm nic firewall remove --vm ${vm.name} --nic ${nic._id}`);
+    const nic_with_firewall = await tests.run(`vm nic show --vm ${vm.id} --nic ${nic.id}`);
+    t.true(nic_with_firewall.firewall === firewall.id);
+    await tests.run(`vm nic firewall remove --vm ${vm.name} --nic ${nic.id}`);
     await common.cleanup();
     await tests.remove('network', network);
     await tests.remove('firewall', firewall);
@@ -190,10 +190,10 @@ ava.serial('vm nic ip life cycle', async t => {
     });
     const vm = await tests.run(`vm create ${common.params.createParams}`);
     const ip = await tests.run('ip create');
-    const nic_list = await tests.run(`vm nic list --vm ${vm._id}`);
+    const nic_list = await tests.run(`vm nic list --vm ${vm.id}`);
 
     await subresourceLifeCycle(t, 'vm nic ip', {
-        commonParams: `--vm ${vm._id} --nic ${nic_list[0]._id}`,
+        commonParams: `--vm ${vm.id} --nic ${nic_list[0].id}`,
         actionParams: `--ip ${ip.name}`,
         deleteParams: '--yes',
         test_fn: x => x.address === ip.address,
@@ -211,11 +211,11 @@ ava.serial('vm nic ip replace', async t => {
     const ip = await tests.run('ip create');
     const new_ip = await tests.run('ip create');
 
-    const nic_list = await tests.run(`vm nic list --vm ${vm._id}`);
-    await tests.run(`vm nic ip add --vm ${vm._id} --nic ${nic_list[0]._id} --ip ${ip._id}`);
-    await tests.run(`vm nic ip replace --vm ${vm._id} --nic ${nic_list[0]._id} --ip ${ip._id} --new-ip ${new_ip._id}`);
-    const new_nic = await tests.run(`vm nic show --vm ${vm._id} --nic ${nic_list[0]._id}`);
-    t.true(new_nic.ip.some(x => x._id === new_ip._id));
+    const nic_list = await tests.run(`vm nic list --vm ${vm.id}`);
+    await tests.run(`vm nic ip add --vm ${vm.id} --nic ${nic_list[0].id} --ip ${ip.id}`);
+    await tests.run(`vm nic ip replace --vm ${vm.id} --nic ${nic_list[0].id} --ip ${ip.id} --new-ip ${new_ip.id}`);
+    const new_nic = await tests.run(`vm nic show --vm ${vm.id} --nic ${nic_list[0].id}`);
+    t.true(new_nic.ip.some(x => x.id === new_ip.id));
 
     await common.cleanup();
     await tests.remove('ip', ip);
@@ -228,16 +228,16 @@ ava.serial('vm nic ip persistent', async t => {
     });
     const vm = await tests.run(`vm create ${common.params.createParams}`);
 
-    const nic_list = await tests.run(`vm nic list --vm ${vm._id}`);
+    const nic_list = await tests.run(`vm nic list --vm ${vm.id}`);
     const ip = nic_list[0].ip[0];
 
     const ip_list = await tests.run('ip list');
-    t.true(!ip_list.some(x => x._id === ip._id));
+    t.true(!ip_list.some(x => x.id === ip.id));
 
-    await tests.run(`vm nic ip persistent --vm ${vm._id} --nic ${nic_list[0]._id} --ip ${ip._id}`);
+    await tests.run(`vm nic ip persistent --vm ${vm.id} --nic ${nic_list[0].id} --ip ${ip.id}`);
 
     const new_ip_list = await tests.run('ip list');
-    t.true(new_ip_list.some(x => x._id === ip._id));
+    t.true(new_ip_list.some(x => x.id === ip.id));
 
     await common.cleanup();
     await tests.remove('ip', ip);
@@ -248,12 +248,12 @@ ava.serial('vm dvd cycle', async t => {
     const vm = await tests.run(`vm create ${common.params.createParams}`);
     const iso = await tests.run(`iso create --name iso-test-${now} --source-url ${tests.iso_url}`);
 
-    await tests.run(`vm dvd insert --vm ${vm._id} --iso ${iso._id}`);
+    await tests.run(`vm dvd insert --vm ${vm.id} --iso ${iso.id}`);
 
-    const list = await tests.run(`vm dvd list --vm ${vm._id}`);
-    t.true(list.some(dvd => dvd.iso._id === iso._id));
+    const list = await tests.run(`vm dvd list --vm ${vm.id}`);
+    t.true(list.some(dvd => dvd.iso.id === iso.id));
 
-    await tests.run(`vm dvd eject --vm ${vm._id} --yes`);
+    await tests.run(`vm dvd eject --vm ${vm.id} --yes`);
 
     await tests.remove('iso', iso);
     await common.cleanup();
@@ -264,7 +264,7 @@ ava.serial('vm serialport log', async t => {
     const vm = await tests.run(`vm create ${common.params.createParams}`);
     t.true(vm.created);
 
-    await tests.run(`vm serialport log --vm ${vm._id}`);
+    await tests.run(`vm serialport log --vm ${vm.id}`);
 
     await common.cleanup();
 });
@@ -295,9 +295,9 @@ ava.serial('vm service change', async t => {
     t.true(vm.memory === 0.5, 'Unexpected memory size of the created virtual machine.');
     await verify_vm_size_match(t, vm, password);
 
-    await tests.run(`vm stop --vm ${vm._id}`);
-    await tests.run(`vm service change --vm ${vm._id} --new-type m2.medium`);
-    const started_vm = await tests.run(`vm start --vm ${vm._id}`);
+    await tests.run(`vm stop --vm ${vm.id}`);
+    await tests.run(`vm service change --vm ${vm.id} --new-type m2.medium`);
+    const started_vm = await tests.run(`vm start --vm ${vm.id}`);
 
     t.true(started_vm.flavour === 'm2.medium', 'Flavor has not been updated');
     t.true(started_vm.cpu === 2, 'Unexpected number of CPUs of the updated virtual machine.');

--- a/bin/website/index.js
+++ b/bin/website/index.js
@@ -57,7 +57,7 @@ const schema = {
 
 const resource = {
     name: 'website',
-    defaultQuery: '[].{id:_id,name:name,image:image,domains:join(\',\',domain), state:state,tags:join(\',\',keys(tag || `{}`) ) }',
+    defaultQuery: '[].{id:id,name:name,image:image,domains:join(\',\',domain), state:state,tags:join(\',\',keys(tag || `{}`) ) }',
     url: () => 'website',
     plugins: genericDefaults.plugins,
     earlyAdoptersOnly: true,

--- a/lib/api.js
+++ b/lib/api.js
@@ -134,8 +134,8 @@ exports.getApiKeySSH = (user) => {
     })
         .then(authToken => {
             logger('info', `Successfully authenticated via SSH to user "${user}".`);
-            exports.setToken(authToken._id);
-            config.set('profile.apiKey', authToken._id);
+            exports.setToken(authToken.id);
+            config.set('profile.apiKey', authToken.id);
             config.set('profile.expires', new Date(authToken.expiry));
             config.set('profile.user', user);
             return config.get('profile');

--- a/lib/api.js
+++ b/lib/api.js
@@ -49,8 +49,8 @@ exports.getApiKey = (user, body) => {
         .send(body)
         .then(rsp => {
             const token = rsp.body;
-            config.set('profile.apiKey', token._id);
-            exports.setToken(token._id);
+            config.set('profile.apiKey', token.id);
+            exports.setToken(token.id);
             config.set('profile.expires', new Date(token.expiry));
             config.set('profile.user', user);
             return Promise.resolve(user);

--- a/lib/config.js
+++ b/lib/config.js
@@ -52,5 +52,5 @@ exports.get = (key, defaultValue) => get(config, key, defaultValue);
 exports.set = (key, value) => set(config, key, value);
 exports.unset = key => unset(config, key);
 exports.plugins = plugins;
-exports.get_active_project = () => exports.getProjectEnv() || exports.get('profile.project._id');
+exports.get_active_project = () => exports.getProjectEnv() || exports.get('profile.project.id');
 exports.store = store;

--- a/lib/ssh.js
+++ b/lib/ssh.js
@@ -116,10 +116,10 @@ const lsFile = (path, connection) => new Promise((resolve, reject) =>
 
 
 const execResource = (resource, auth, cmd) => {
-    console.log(new Date().toISOString(), `[resource: ${resource._id}]`, cmd);
+    console.log(new Date().toISOString(), `[resource: ${resource.id}]`, cmd);
     return execute(cmd, Object.assign({
         host: resource.fqdn,
-        username: resource._id,
+        username: resource.id,
     }, auth));
 };
 

--- a/lib/tests.js
+++ b/lib/tests.js
@@ -98,7 +98,7 @@ const run = async (cmd) => {
 const show = async (type, resource, options = {}, history = []) => {
     let resource_id = resource;
     if (typeof resource_id === 'object') {
-        resource_id = resource_id._id;
+        resource_id = resource_id.id;
     }
     return run({
         cmd: `${type} show --${getOption(type)} '${resource_id}' ${options.showParams || ''}`,
@@ -109,7 +109,7 @@ const show = async (type, resource, options = {}, history = []) => {
 const remove = async (type, resource, options = {}, history = []) => {
     let resource_id = resource;
     if (typeof resource_id === 'object') {
-        resource_id = resource_id._id;
+        resource_id = resource_id.id;
     }
 
     return run({
@@ -145,13 +145,13 @@ const subresourceLifeCycle = (options = {}) => async t => {
     t.true(Array.isArray(sub_list));
     t.true(sub_list.length > 0, `The ${options.resourceType} should have at least one ${options.type}`);
     const last_resource = sub_list[sub_list.length - 1];
-    const subresource = await run(`${categoryName} show ${options.showParams || ''} ${commonParams} --${getOption(options.type)} ${last_resource._id}`);
-    t.true(last_resource._id === subresource._id);
+    const subresource = await run(`${categoryName} show ${options.showParams || ''} ${commonParams} --${getOption(options.type)} ${last_resource.id}`);
+    t.true(last_resource.id === subresource.id);
 
     if (!options.skipRename) {
         const new_name = `renamed-${subresource.name}`;
-        await run(`${categoryName} rename ${commonParams} --${getOption(options.type)} ${subresource._id} --new-name '${new_name}' ${options.renameParams || ''}`);
-        const renamed = await run(`${categoryName} show ${options.showParams || ''} --${getOption(options.type)} ${subresource._id}`);
+        await run(`${categoryName} rename ${commonParams} --${getOption(options.type)} ${subresource.id} --new-name '${new_name}' ${options.renameParams || ''}`);
+        const renamed = await run(`${categoryName} show ${options.showParams || ''} --${getOption(options.type)} ${subresource.id}`);
         t.true(renamed.name === new_name);
     }
 };
@@ -193,7 +193,7 @@ const resourceLifeCycle = (type, options = {}) => wrap(type, options, requireSla
         }
     }
 
-    t.true(list.some(d => d._id === resource._id));
+    t.true(list.some(d => d.id === resource.id));
 
     if (options.delayStateTest) {
         await delay(options.delayStateTest);
@@ -232,11 +232,11 @@ const resourceLifeCycle = (type, options = {}) => wrap(type, options, requireSla
     // Platform test end
 
     if (!options.skipTransfer) {
-        await run(`${type} transfer --${getOption(type)} ${resource._id} --new-project '${projects.slave}'`);
-        await t.throwsAsync(() => run(`${type} show --${getOption(type)} ${resource._id}`));
+        await run(`${type} transfer --${getOption(type)} ${resource.id} --new-project '${projects.slave}'`);
+        await t.throwsAsync(() => run(`${type} show --${getOption(type)} ${resource.id}`));
         await run(`project select --project '${projects.slave}'`);
-        const transfered = await run(`${type} show --${getOption(type)} ${resource._id}`);
-        await run(`${type} transfer --${getOption(type)} ${resource._id} --new-project '${projects.master}'`);
+        const transfered = await run(`${type} show --${getOption(type)} ${resource.id}`);
+        await run(`${type} transfer --${getOption(type)} ${resource.id} --new-project '${projects.master}'`);
         await run(`project select --project '${projects.master}'`);
 
         // Platform test start
@@ -283,7 +283,7 @@ const resourceAccessCycle = (type, project, options = {}) => wrap(type, options,
         {name: 'revoke', result: false},
     ];
 
-    const commonParams = `--${getOption(type)} ${resource._id}`;
+    const commonParams = `--${getOption(type)} ${resource.id}`;
     for (const action of actions) {
         await run({
             cmd: `${type} access ${action.name} ${commonParams} --project '${project}'`,
@@ -305,7 +305,7 @@ const resourceRename = (type, options = {}) => wrap(type, options, async (t, res
     const new_name = `${resource.name}-renamed`;
 
     await run({
-        cmd: `${type} rename --${getOption(type)} ${resource._id} --new-name ${new_name}`,
+        cmd: `${type} rename --${getOption(type)} ${resource.id} --new-name ${new_name}`,
         history: history,
     });
 
@@ -314,7 +314,7 @@ const resourceRename = (type, options = {}) => wrap(type, options, async (t, res
         history: history,
     });
 
-    t.true(resource._id === renamed_resource._id);
+    t.true(resource.id === renamed_resource.id);
     t.true(renamed_resource.name === new_name);
 });
 
@@ -362,7 +362,7 @@ const credentialsLifeCycle = (type, options = {}) => async t => {
         await openApiValidator('#/components/schemas/credential.certificate', credentials);
 
         await run(`${type} rename --${getOption(type)} ${name} --new-name renamed-${name} ${renameParams}`);
-        await run(`${type} show ${showParams} --${getOption(type)} ${credentials._id}`);
+        await run(`${type} show ${showParams} --${getOption(type)} ${credentials.id}`);
 
         await remove(type, credentials, options);
     } finally {
@@ -385,11 +385,11 @@ const passwordLifeCycle = async (t, type, resource) => {
     await openApiValidator('#/components/schemas/credential.password', password);
 
     await run(`${type} credential password rename --${getOption(type)} ${resource.name} --password ${name} --new-name ${new_name}`);
-    const renamed_password = await run(`${type} credential password show --${getOption(type)} ${resource.name} --password ${password._id}`);
+    const renamed_password = await run(`${type} credential password show --${getOption(type)} ${resource.name} --password ${password.id}`);
     t.true(renamed_password.name === new_name);
 
     await remove(`${type} credential password`, password, {
-        deleteParams: `--${getOption(type)} ${resource._id}`,
+        deleteParams: `--${getOption(type)} ${resource.id}`,
     });
 };
 
@@ -401,7 +401,7 @@ const resourceResizeCycle = (type, options) => async t => {
     const resource = await run(`${type} create ${createParams} --size ${initialSize}`);
     t.true(resource.size === initialSize);
 
-    await run(`${type} resize --${type} ${resource._id} --size ${targetSize}`);
+    await run(`${type} resize --${type} ${resource.id} --size ${targetSize}`);
 
     const resized_resource = await show(type, resource);
     t.true(resized_resource.size === targetSize);
@@ -416,15 +416,15 @@ const accessRuleLifeCycle = async (t, type, options) => {
     const name = `rule-${now}`;
     const resource = await run(`${type} add ${options.commonParams || ''} --name ${name} --type geo --value PL`);
 
-    const tester = x => x._id === resource._id;
+    const tester = x => x.id === resource.id;
     const list = await run(`${type} list ${options.commonParams || ''}`);
     t.true(list.some(tester));
 
-    const resource_show = await run(`${type} show ${options.commonParams || ''} --rule ${resource._id}`);
+    const resource_show = await run(`${type} show ${options.commonParams || ''} --rule ${resource.id}`);
 
     await openApiValidator('#/components/schemas/credential.password', resource_show);
 
-    await run(`${type} delete ${options.commonParams || ''} --yes --rule ${resource._id}`);
+    await run(`${type} delete ${options.commonParams || ''} --yes --rule ${resource.id}`);
     const updated_list = await run(`${type} list ${options.commonParams || ''}`);
     t.true(!updated_list.some(tester));
 };


### PR DESCRIPTION
Depends on #376, #374

See missing ```id``` property:
```
$ h1 database credential password list --database database-credentials-password-life-cycle---mysql-5-7-1562896723439 -o json -v
verbose: GET https://api.hyperone.com/v1/database/database-credentials-password-life-cycle---mysql-5-7-1562896723439/credential
verbose: headers
{
  "x-auth-token": "...",
  "x-project": "5af0bbbcb7802508ad844caa"
}
verbose: query {}
verbose: 200 OK
[
  {
    createdBy: '...',
    createdOn: '2019-07-12T01:58:49.520Z',
    name: 'renamed-database-password-life-cycle-1562896650978',
    type: 'mysql',
    _id: '5d27e95924d7fd5be4320236',
    value: 'F3D79937B775828EFC95A3F2DFE7D866'
  }
]
$ ssh -o "User=..." api.hyperone.com -s rbx-auth
{"_id":"...","expiry":"2019-07-12T11:25:29.718Z","createdBy":"...","createdOn":"2019-07-12T10:25:29.718Z","access":[{"method":"ALL","path":"/","_id":"5d286019e450853d609cc5d4"}],"clientIp":"::ffff:10.80.7.50","userAgent":"SSH-2.0-OpenSSH_7.2p2 Ubuntu-4ubuntu2.8"}
```