### PR TITLE
test: website, Add tests for access snapshot via .zfs

### DIFF
--- a/bin/website/tests.js
+++ b/bin/website/tests.js
@@ -321,11 +321,25 @@ ava.serial('website snapshot restore', async t => {
     await tests.run(`website snapshot create --website ${website.name} --name ${snapshotName}`);
     const websiteRestored = await tests.run(`website create --name ${tests.getName('restored', t.title)} ${commonCreateParams} --password ${password} --source-website ${website.id} --source-snapshot ${snapshotName}`);
     await tests.run(`website snapshot delete --yes --website ${website.name} --snapshot ${snapshotName}`);
-    const contentRestored = await ssh.execResource(website, { password }, 'cat public/test.txt');
+    const contentRestored = await ssh.execResource(websiteRestored, { password }, 'cat public/test.txt');
     t.true(contentRestored.trim() === content);
     await tests.remove('website', website); // remove source of snapshot first
     await tests.remove('website', websiteRestored);
 });
+
+ava.serial('website snapshot access via .zfs', async t => {
+    const password = await tests.getToken();
+    const website = await tests.run(`website create --name ${tests.getName(t.title)} ${commonCreateParams} --password ${password}`);
+    const content = await tests.getToken();
+    await putFileWebsite(website, { password }, 'public/test.txt', content);
+    const snapshotName = tests.getName('snapshot', t.title);
+    await tests.run(`website snapshot create --website ${website.name} --name ${snapshotName}`);
+    const contentRestored = await ssh.execResource(website, { password }, `cat /data/.zfs/snapshot/${snapshotName}/public/test.txt`);
+    t.true(contentRestored.trim() === content);
+    await tests.run(`website snapshot delete --yes --website ${website.name} --snapshot ${snapshotName}`);
+    await tests.remove('website', website);
+});
+
 
 ava.serial('website log', async t => {
     const password = await tests.getToken();


### PR DESCRIPTION
```
$ npm run test -- --match 'website snapshot access via .zfs'

> @hyperone/cli@1.9.0 test /home/adas/Devel/h1-cli
> npx ava --verbose "--match" "website snapshot access via .zfs"


2020-01-07T18:45:55.823Z node h1 website create --name website-snapshot-access-via--zfs-1578422755819 --type website --image h1cr.io/website/php-apache\:7.2 --password 03ca370aa3790a6aecf2e709334bddeb3a92bd5ac408b06816737cbd5b9b7def2bffc19d87482681c616e3e23b330c81 -o js
2020-01-07T18:45:59.066Z Upload content to website 5e14d1e49791c6bb95f4e412 at 'public/test.txt'
2020-01-07T18:46:00.987Z node h1 website snapshot create --website website-snapshot-access-via--zfs-1578422755819 --name snapshot-website-snapshot-access-via--zfs-1578422760984 -o js
2020-01-07T18:46:02.634Z [resource: 5e14d1e49791c6bb95f4e412] cat /data/.zfs/snapshot/snapshot-website-snapshot-access-via--zfs-1578422760984/public/test.txt
[5e14d1e49791c6bb95f4e412.website.pl-waw-1.hyperone.cloud]:cat /data/.zfs/snapshot/snapshot-website-snapshot-access-via--zfs-1578422760984/public/test.txt
  ✖ bin › website › tests › website snapshot access via .zfs Rejected promise returned by test

  1 test failed

  bin › website › tests › website snapshot access via .zfs


  Rejected promise returned by test. Reason:

  {
    code: 1,
    command: 'cat /data/.zfs/snapshot/snapshot-website-snapshot-access-via--zfs-1578422760984/public/test.txt',
    msg: 'Execution of SSH command fail',
    output: `cat: /data/.zfs/snapshot/snapshot-website-snapshot-access-via--zfs-1578422760984/public/test.txt: Object is remote␊
    `,
    signal: undefined,
  }

npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! @hyperone/cli@1.9.0 test: `npx ava --verbose "--match" "website snapshot access via .zfs"`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the @hyperone/cli@1.9.0 test script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/adas/.npm/_logs/2020-01-07T18_46_04_220Z-debug.log
```

Few issues in that area reported in ZOL ( https://github.com/zfsonlinux/zfs/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+%22Object+is+remote%22 ) history. On host following version of ZFS in use:
```
/sys/module/zfs/version:0.8.2-2~bpo10+1
```
Issue fix applied to 0.8.3 ( https://github.com/zfsonlinux/zfs/issues/9461#issuecomment-560504834 ), and "it is a regression in 0.8.2 release" ( https://github.com/zfsonlinux/zfs/issues/9461#issuecomment-560479763 ).

CC: @gregorybrzeski 