### PR TITLE
Add autocomplete for CLI

### DIFF
--- a/bin/agent/index.js
+++ b/bin/agent/index.js
@@ -3,6 +3,7 @@ const text = require('lib/text');
 const genericDefaults = require('bin/generic/defaults');
 const genericResource = require('bin/generic');
 const genericAction = require('bin/generic/action');
+const complete = require('lib/complete');
 
 const schema = {
     name: {
@@ -17,6 +18,7 @@ const schema = {
         required: true,
         onCreate: true,
         destBody: 'service',
+        complete: complete.completeService('agent'),
     },
     credentials: {
         virtual: true,

--- a/bin/config/autocomplete/index.js
+++ b/bin/config/autocomplete/index.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const Cli = require('lib/cli');
+
+const category = Cli.createCategory('autocomplete', {
+    description: 'Manage autocomplete for CLI',
+    priority: 25,
+});
+
+category.addChild(require('./init'));
+category.addChild(require('./remove'));
+
+module.exports = category;

--- a/bin/config/autocomplete/init/examples.md
+++ b/bin/config/autocomplete/init/examples.md
@@ -1,0 +1,11 @@
+# Get default virtual machine type for a new one
+
+```
+{{command_name}}
+```
+
+# Introduces changes
+
+If you use Bash, it will create a file at ```~/.h1/completion.sh``` and append a loader code to ```~/.bash_profile``` file.
+If you use Zsh, it appends a loader code to ```~/.zshrc``` file.
+If you use Fish, it appends a loader code to ```~/.config/fish/config.fish``` file.

--- a/bin/config/autocomplete/init/index.js
+++ b/bin/config/autocomplete/init/index.js
@@ -3,7 +3,7 @@
 const Cli = require('lib/cli');
 const complete = require('lib/complete');
 
-module.exports = Cli.createCommand('setup', {
+module.exports = Cli.createCommand('init', {
     dirname: __dirname,
     description: 'Update shell configuration to support autocomplete',
     plugins: [

--- a/bin/config/autocomplete/init/index.js
+++ b/bin/config/autocomplete/init/index.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const Cli = require('lib/cli');
+const complete = require('lib/complete');
+
+module.exports = Cli.createCommand('setup', {
+    dirname: __dirname,
+    description: 'Update shell configuration to support autocomplete',
+    plugins: [
+        require('bin/_plugins/outputFormat'),
+    ],
+    handler: args => {
+        complete.autocomplete(Cli.root(args)).setupShellInitFile();
+        return 'autocomplete set';
+    },
+});

--- a/bin/config/autocomplete/remove/examples.md
+++ b/bin/config/autocomplete/remove/examples.md
@@ -1,0 +1,5 @@
+# Update shell configuration to disable autocomplete
+
+```
+{{command_name}}
+```

--- a/bin/config/autocomplete/remove/index.js
+++ b/bin/config/autocomplete/remove/index.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const Cli = require('lib/cli');
+const complete = require('lib/complete');
+
+module.exports = Cli.createCommand('remove', {
+    dirname: __dirname,
+    description: 'Update shell configuration to remove autocomplete',
+    plugins: [
+        require('bin/_plugins/outputFormat'),
+    ],
+    handler: () => {
+        complete.cleanupShellInitFile();
+        return 'autocomplete removed';
+    },
+});

--- a/bin/config/index.js
+++ b/bin/config/index.js
@@ -11,5 +11,6 @@ category.addChild(require('./show'));
 category.addChild(require('./set'));
 category.addChild(require('./get'));
 category.addChild(require('./unset'));
+category.addChild(require('./autocomplete'));
 
 module.exports = category;

--- a/bin/container/create/index.js
+++ b/bin/container/create/index.js
@@ -2,6 +2,7 @@
 
 const Cli = require('lib/cli');
 const registry = require('../registry');
+const complete = require('lib/complete');
 
 const options = {
     name: {
@@ -15,9 +16,10 @@ const options = {
         required: true,
     },
     type: {
-        description: 'Container type',
+        description: 'Container type name or ID',
         type: 'string',
         required: true,
+        complete: complete.completeService('container'),
     },
     expose: {
         description: 'Mapping port to expose to the world as external:internal',

--- a/bin/database/index.js
+++ b/bin/database/index.js
@@ -1,6 +1,7 @@
 'use strict';
 const genericDefaults = require('bin/generic/defaults');
 const genericResource = require('bin/generic');
+const complete = require('lib/complete');
 
 const schema = {
     name: {
@@ -10,11 +11,12 @@ const schema = {
         onCreate: true,
     },
     type: {
-        description: 'Database type',
+        description: 'Database type name or ID',
         type: 'string',
         required: true,
         onCreate: true,
         destBody: 'service',
+        complete: complete.completeService('database'),
     },
     credentials: {
         virtual: true,

--- a/bin/disk/create/index.js
+++ b/bin/disk/create/index.js
@@ -7,6 +7,7 @@ const path = require('path');
 const fs = require('fs');
 
 const Cli = require('lib/cli');
+const complete = require('lib/complete');
 
 const options = {
     name: {
@@ -17,6 +18,7 @@ const options = {
     type: {
         description: 'Disk type ID or name. Required if no source disk is specified',
         type: 'string',
+        complete: complete.completeService('disk'),
     },
     size: {
         description: 'Disk size in GiB. Required if no source file and no disk is specified',

--- a/bin/dns/zone/index.js
+++ b/bin/dns/zone/index.js
@@ -3,6 +3,7 @@
 const genericResource = require('bin/generic');
 const defaults = require('bin/generic/defaults');
 const addTrailingDot = require('../lib').addTrailingDot;
+const autocomplete = require('lib/complete');
 
 const schema = {
     name: {
@@ -24,6 +25,7 @@ const schema = {
         required: true,
         onCreate: true,
         destBody: 'service',
+        complete: autocomplete.completeService('zone'),
     },
     tags: {
         virtual: true,

--- a/bin/journal/index.js
+++ b/bin/journal/index.js
@@ -2,6 +2,7 @@
 
 const genericDefaults = require('bin/generic/defaults');
 const genericResource = require('bin/generic');
+const complete = require('lib/complete');
 
 const schema = {
     name: {
@@ -16,6 +17,7 @@ const schema = {
         required: false,
         onCreate: true,
         destBody: 'service',
+        complete: complete.completeService('journal'),
     },
     retention: {
         description: 'Data retention period (in days)',

--- a/bin/registry/index.js
+++ b/bin/registry/index.js
@@ -2,6 +2,7 @@
 const text = require('lib/text');
 const genericDefaults = require('bin/generic/defaults');
 const genericResource = require('bin/generic');
+const complete = require('lib/complete');
 
 const schema = {
     name: {
@@ -16,6 +17,7 @@ const schema = {
         required: true,
         onCreate: true,
         destBody: 'service',
+        complete: complete.completeService('registry'),
     },
     credentials: {
         virtual: true,

--- a/bin/reservation/index.js
+++ b/bin/reservation/index.js
@@ -2,6 +2,7 @@
 
 const genericDefaults = require('bin/generic/defaults');
 const genericResource = require('bin/generic');
+const complete = require('lib/complete');
 
 const schema = {
     name: {
@@ -11,11 +12,12 @@ const schema = {
         onCreate: true,
     },
     type: {
-        description: 'Reservation type',
+        description: 'Reservation type name or ID',
         type: 'string',
         required: true,
         onCreate: true,
         destBody: 'service',
+        reservation: complete.completeService('reservation'),
     },
     tags: {
         virtual: true,

--- a/bin/start.js
+++ b/bin/start.js
@@ -2,6 +2,7 @@
 
 const cli = require('./index');
 const logger = require('lib/logger');
+const complete = require('../lib/complete');
 
 process.env.NODE_ENV = process.pkg ? 'production' : process.env.NODE_ENV;
 
@@ -12,10 +13,10 @@ const matches = (prop, value, callback) => err => {
     throw err;
 };
 
-cli.run()
+complete.autocomplete(cli, () => cli.run()
     .then(result => {
         if (typeof result === 'object') {
-            console.dir(result, {depth: null});
+            console.dir(result, { depth: null });
         } else if (result) {
             console.log(result);
         }
@@ -62,4 +63,5 @@ cli.run()
         logger('error', err.stack);
 
         process.exit(99);
-    });
+    })
+);

--- a/bin/vm/create/index.js
+++ b/bin/vm/create/index.js
@@ -5,8 +5,8 @@ const fs = require('lib/fs');
 const { hashPassword } = require('lib/credentials');
 const genericDefaults = require('bin/generic/defaults');
 const logger = require('lib/logger');
-
 const DEFAULT_IMAGE = 'debian';
+const complete = require('lib/complete');
 
 const options = {
     name: {
@@ -18,6 +18,7 @@ const options = {
         description: 'Virtual machine type name or ID',
         type: 'string',
         required: true,
+        complete: complete.completeService('vm'),
     },
     password: {
         description: 'Initial administrator user password',
@@ -52,6 +53,7 @@ const options = {
     'os-disk-type': {
         description: 'OS disk type. Parameter excludes the use of "os-disk" parameter.',
         type: 'string',
+        complete: complete.completeService('disk'),
     },
     'os-disk-size': {
         description: 'OS disk size. Parameter excludes the use of "os-disk" parameter.',

--- a/bin/vm/nic/create/index.js
+++ b/bin/vm/nic/create/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Cli = require('lib/cli');
+const complete = require('lib/complete');
 
 module.exports = (resource) => {
     const options = {
@@ -10,9 +11,10 @@ module.exports = (resource) => {
             required: false,
         },
         type: {
-            description: 'Type of Network Adapter',
+            description: 'Network Adapter type or ID',
             type: 'string',
             required: true,
+            complete: complete.completeService('netadp'),
         },
         ip: {
             description: 'IP address to assign',

--- a/bin/volume/index.js
+++ b/bin/volume/index.js
@@ -2,6 +2,7 @@
 
 const genericDefaults = require('bin/generic/defaults');
 const genericResource = require('bin/generic');
+const complete = require('lib/complete');
 
 const schema = {
     name: {
@@ -16,6 +17,7 @@ const schema = {
         required: true,
         onCreate: true,
         destBody: 'service',
+        complete: complete.completeService('volume'),
     },
     size: {
         description: 'Volume size in GiB',

--- a/bin/website/index.js
+++ b/bin/website/index.js
@@ -3,6 +3,7 @@ const genericDefaults = require('bin/generic/defaults');
 const genericAction = require('bin/generic/action');
 const genericResource = require('bin/generic');
 const text = require('lib/text');
+const complete = require('lib/complete');
 
 const schema = {
     name: {
@@ -12,11 +13,12 @@ const schema = {
         onCreate: true,
     },
     type: {
-        description: 'Website type',
+        description: 'Website type name or ID',
         type: 'string',
         required: true,
         onCreate: true,
         destBody: 'service',
+        complete: complete.completeService('website'),
     },
     domain: {
         description: 'Domain name',

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,5 +1,8 @@
 # TOC
 
+  * [h1 config autocomplete](#h1-config-autocomplete) - Manage autocomplete for CLI
+    * [h1 config autocomplete setup](#h1-config-autocomplete-setup) - Update shell configuration to support autocomplete
+    * [h1 config autocomplete remove](#h1-config-autocomplete-remove) - Update shell configuration to remove autocomplete
   * [h1 config show](#h1-config-show) - Show config
   * [h1 config set](#h1-config-set) - Set config value
   * [h1 config get](#h1-config-get) - Get config value
@@ -11,6 +14,52 @@
 ## h1 config
 
 Manage config of CLI
+
+## h1 config autocomplete
+
+Manage autocomplete for CLI
+
+## h1 config autocomplete setup
+
+Update shell configuration to support autocomplete
+
+### Syntax
+
+```h1 config autocomplete setup | [--debug]```
+### Examples
+
+#### Get default virtual machine type for a new one
+
+```
+h1 config autocomplete setup
+```
+
+#### Introduces changes
+
+If you use Bash, it will create a file at ```~/.h1/completion.sh``` and append a loader code to ```~/.bash_profile``` file.
+If you use Zsh, it appends a loader code to ```~/.zshrc``` file.
+If you use Fish, it appends a loader code to ```~/.config/fish/config.fish``` file.
+
+### Optional arguments
+
+| Name | Default | Description |
+| ---- | ------- | ----------- |
+| ```--debug``` |  | Create alias for debugging |
+
+## h1 config autocomplete remove
+
+Update shell configuration to remove autocomplete
+
+### Syntax
+
+```h1 config autocomplete remove | ```
+### Examples
+
+#### Update shell configuration to disable autocomplete
+
+```
+h1 config autocomplete remove
+```
 
 ## h1 config show
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -25,7 +25,7 @@ Update shell configuration to support autocomplete
 
 ### Syntax
 
-```h1 config autocomplete setup | [--debug]```
+```h1 config autocomplete setup | ```
 ### Examples
 
 #### Get default virtual machine type for a new one
@@ -39,12 +39,6 @@ h1 config autocomplete setup
 If you use Bash, it will create a file at ```~/.h1/completion.sh``` and append a loader code to ```~/.bash_profile``` file.
 If you use Zsh, it appends a loader code to ```~/.zshrc``` file.
 If you use Fish, it appends a loader code to ```~/.config/fish/config.fish``` file.
-
-### Optional arguments
-
-| Name | Default | Description |
-| ---- | ------- | ----------- |
-| ```--debug``` |  | Create alias for debugging |
 
 ## h1 config autocomplete remove
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,7 +1,7 @@
 # TOC
 
   * [h1 config autocomplete](#h1-config-autocomplete) - Manage autocomplete for CLI
-    * [h1 config autocomplete setup](#h1-config-autocomplete-setup) - Update shell configuration to support autocomplete
+    * [h1 config autocomplete init](#h1-config-autocomplete-init) - Update shell configuration to support autocomplete
     * [h1 config autocomplete remove](#h1-config-autocomplete-remove) - Update shell configuration to remove autocomplete
   * [h1 config show](#h1-config-show) - Show config
   * [h1 config set](#h1-config-set) - Set config value
@@ -19,19 +19,19 @@ Manage config of CLI
 
 Manage autocomplete for CLI
 
-## h1 config autocomplete setup
+## h1 config autocomplete init
 
 Update shell configuration to support autocomplete
 
 ### Syntax
 
-```h1 config autocomplete setup | ```
+```h1 config autocomplete init | ```
 ### Examples
 
 #### Get default virtual machine type for a new one
 
 ```
-h1 config autocomplete setup
+h1 config autocomplete init
 ```
 
 #### Introduces changes

--- a/docs/container.md
+++ b/docs/container.md
@@ -60,7 +60,7 @@ h1 container create --name nginx --type b1.nano --image registry.example.com/my-
 | ---- | ------- | ----------- |
 | ```--name NAME``` |  | Container name |
 | ```--image IMAGE``` |  | Container image eg. h1cr.io/website/php-apache |
-| ```--type TYPE``` |  | Container type |
+| ```--type TYPE``` |  | Container type name or ID |
 
 ### Optional arguments
 

--- a/docs/database.md
+++ b/docs/database.md
@@ -68,7 +68,7 @@ h1 database create --name my-database --type mysql:5.7 --password my-password
 | Name | Default | Description |
 | ---- | ------- | ----------- |
 | ```--name NAME``` |  | Database name |
-| ```--type TYPE``` |  | Database type |
+| ```--type TYPE``` |  | Database type name or ID |
 
 ### Optional arguments
 

--- a/docs/reservation.md
+++ b/docs/reservation.md
@@ -49,7 +49,7 @@ h1 reservation create --name my-reservation-name --type 'm2.tiny, 1 year'
 | Name | Default | Description |
 | ---- | ------- | ----------- |
 | ```--name NAME``` |  | Reservation name |
-| ```--type TYPE``` |  | Reservation type |
+| ```--type TYPE``` |  | Reservation type name or ID |
 
 ### Optional arguments
 

--- a/docs/vm.md
+++ b/docs/vm.md
@@ -589,7 +589,7 @@ Note (4): To list available networks use ```h1 network list```.
 | Name | Default | Description |
 | ---- | ------- | ----------- |
 | ```--vm VM``` |  | Virtual machine name or ID |
-| ```--type TYPE``` |  | Type of Network Adapter |
+| ```--type TYPE``` |  | Network Adapter type or ID |
 
 ### Optional arguments
 

--- a/docs/website.md
+++ b/docs/website.md
@@ -98,7 +98,7 @@ Hint: Use ```h1 project credentials list``` or ```h1 user credentials list``` to
 | Name | Default | Description |
 | ---- | ------- | ----------- |
 | ```--name NAME``` |  | Website name |
-| ```--type TYPE``` |  | Website type |
+| ```--type TYPE``` |  | Website type name or ID |
 | ```--image IMAGE``` |  | Website image |
 
 ### Optional arguments

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -25,6 +25,7 @@ const genericOptionsGroups = {
             description: 'Key=value of tag',
             type: 'string',
             action: 'append',
+            complete: () => ['protected'],
         },
     }),
     credentials: (options) => {
@@ -113,6 +114,13 @@ module.exports = {
             }
         }
         return nodes;
+    },
+    root: (node) => {
+        let cur = node.$node || node;
+        while (cur.parent) {
+            cur = cur.parent;
+        }
+        return cur;
     },
     get_full_name: (node) => {
         const names = [node.name];

--- a/lib/complete.js
+++ b/lib/complete.js
@@ -5,10 +5,12 @@ const api = require('lib/api');
 
 const completeService = (resource) => async (start) => {
     const resp = await api.get('/service', { resource, type: 'flavour' });
-    const replies = [
-        ...resp.map(x => x.name),
-        ...resp.map(x => x.id),
-    ];
+    const replies = resp.map(x => x.name);
+
+    if (start.trim().length > 0) {
+        replies.push(...resp.map(x => x.id));
+    }
+
     const result = replies.filter(x => x.startsWith(start));
     return result;
 };

--- a/lib/complete.js
+++ b/lib/complete.js
@@ -17,15 +17,12 @@ const autocomplete = (cli, next) => {
     // const om = omelette(cli.name).tree(tree(cli));
     const om = omelette(cli.name);
     om.onAsync('complete', function (fragment, { line }) {
-        const args = line.split(' ')
-            .map((c) => c.trim());
+        const args = line.split(' ').map(c => c.trim());
 
         let arg;
         let index;
         let parent_category;
         let current_category;
-
-        // start from 1, so to discard "h1" word
         for (index = 1, current_category = cli; index < args.length; index++) {
             arg = args[index];
             if (!current_category.options) {
@@ -40,11 +37,10 @@ const autocomplete = (cli, next) => {
         const last_category = current_category ? current_category : parent_category;
         const all_entries = last_category.children.map(x => x.name);
         const current_command = last_category.children.find(c => c.name === arg);
-
         // autocomplete category or command for category
-        if (current_category) {
+        if (current_category || !current_command) {
             //return command and categories combined
-            return this.reply(all_entries);
+            return this.reply(all_entries.filter(c => c.startsWith(arg)));
         }
         let command_options;
         let options_names;
@@ -56,18 +52,17 @@ const autocomplete = (cli, next) => {
             );
             options_names = Object.keys(command_options).map(x => `--${x}`);
         }
-        // autocomplete categories and commands name for last args
-        if (index === args.length - 1) {
+
+        // autocomplete categories for root of category / command
+        if (index === args.filter(x => x !== '').length - 1) {
             if (current_command) {
+                // ... of command
                 return this.reply(options_names);
             }
+            // ... of category
             return this.reply(all_entries.filter(c => c.startsWith(arg)));
         }
 
-        // autocomplete for command
-        if (!current_command) {
-            return this.reply([]);
-        }
         // autocomplete option name
         let last_arg = args[args.length - 1];
         if (last_arg == '') {
@@ -78,7 +73,9 @@ const autocomplete = (cli, next) => {
                 return option.complete(start);
             }
             if (option.choices) {
-                return option.choices;
+                return option.choices.filter(c =>
+                    c !== start && c.startsWith(start)
+                );
             }
             if (option.type == 'boolean') {
                 return options_names;
@@ -88,8 +85,7 @@ const autocomplete = (cli, next) => {
             }
             return [];
         };
-
-        if (last_arg.startsWith('--')) { // autocomplete for option name
+        if (last_arg.startsWith('-')) { // autocomplete for option name
             const option = command_options[last_arg.replace(/^-+/, '')];
             if (option) { // full option name provided
                 return this.reply(completeForOption(option));

--- a/lib/complete.js
+++ b/lib/complete.js
@@ -1,0 +1,118 @@
+'use strict';
+
+const omelette = require('omelette');
+const api = require('lib/api');
+
+const completeService = (resource) => async (start) => {
+    const resp = await api.get('/service', { resource, type: 'flavour' });
+    const replies = [
+        ...resp.map(x => x.name),
+        ...resp.map(x => x.id),
+    ];
+    const result = replies.filter(x => x.startsWith(start));
+    return result;
+};
+
+const autocomplete = (cli, next) => {
+    // const om = omelette(cli.name).tree(tree(cli));
+    const om = omelette(cli.name);
+    om.onAsync('complete', function (fragment, { line }) {
+        const args = line.split(' ')
+            .map((c) => c.trim());
+
+        let arg;
+        let index;
+        let parent_category;
+        let current_category;
+
+        // start from 1, so to discard "h1" word
+        for (index = 1, current_category = cli; index < args.length; index++) {
+            arg = args[index];
+            if (!current_category.options) {
+                break;
+            }
+            parent_category = current_category;
+            current_category = current_category.children.find(x => x.name == arg && x.children);
+            if (!current_category) {
+                break;
+            }
+        }
+        const last_category = current_category ? current_category : parent_category;
+        const all_entries = last_category.children.map(x => x.name);
+        const current_command = last_category.children.find(c => c.name === arg);
+
+        // autocomplete category or command for category
+        if (current_category) {
+            //return command and categories combined
+            return this.reply(all_entries);
+        }
+        let command_options;
+        let options_names;
+        if (current_command) {
+            command_options = Object.assign({},
+                ...Object.values(current_command.optionGroups || {}),
+                current_command.options || {},
+                ...(current_command.plugins || []).map(p => p.options)
+            );
+            options_names = Object.keys(command_options).map(x => `--${x}`);
+        }
+        // autocomplete categories and commands name for last args
+        if (index === args.length - 1) {
+            if (current_command) {
+                return this.reply(options_names);
+            }
+            return this.reply(all_entries.filter(c => c.startsWith(arg)));
+        }
+
+        // autocomplete for command
+        if (!current_command) {
+            return this.reply([]);
+        }
+        // autocomplete option name
+        let last_arg = args[args.length - 1];
+        if (last_arg == '') {
+            last_arg = args[args.length - 2];
+        }
+        const completeForOption = (option, start = '') => {
+            if (option.complete) {
+                return option.complete(start);
+            }
+            if (option.choices) {
+                return option.choices;
+            }
+            if (option.type == 'boolean') {
+                return options_names;
+            }
+            if (option.defaultValue) {
+                return [option.defaultValue];
+            }
+            return [];
+        };
+
+        if (last_arg.startsWith('--')) { // autocomplete for option name
+            const option = command_options[last_arg.replace(/^-+/, '')];
+            if (option) { // full option name provided
+                return this.reply(completeForOption(option));
+            }
+            return this.reply(
+                options_names.filter(c =>
+                    c !== last_arg && c.startsWith(last_arg)
+                )
+            );
+        }
+        // attempt autocomplete for value
+        const option = command_options[args[args.length - 2].replace(/^-+/, '')];
+        if (option) {
+            return this.reply(completeForOption(option, last_arg));
+        }
+        return this.reply([]);
+    });
+    om.next(next);
+    om.init();
+    return om;
+};
+
+module.exports = {
+    autocomplete,
+    completeService,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -4176,6 +4176,11 @@
         "symbol-observable": "^1.0.4"
       }
     },
+    "omelette": {
+      "version": "0.4.12",
+      "resolved": "https://registry.npmjs.org/omelette/-/omelette-0.4.12.tgz",
+      "integrity": "sha512-f/GsNOZIxHnNo9hHguQ8bNWXogfTebmvXR5Jg1apRakWO/PDSUbCOFlp9Rv4IPnS59sjZTPqkHZ2seFx8opJXA=="
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "marked-terminal": "^3.3.0",
     "ms": "^2.1.2",
     "node-rsa": "^0.4.2",
+    "omelette": "^0.4.12",
     "opn": "^6.0.0",
     "progress": "^2.0.3",
     "qrcode": "^1.4.4",


### PR DESCRIPTION
Autocomplete currently supports:
- names of all categories and commands
- names of all options
- values of options 🌟 for:
    - names of public flavours (Async🎆)
    - all platform-special tags
    - CLI-specific enums like ```--output```

To use on Linux use following command:

```bash
$ npm run lint
$ h1 config autocomplete init
$ source ~/.bash_profile
```

Usage examples:

```bash
$ h1 dns zone list --<TAB>
--dry-run         --no-wait         --output          --project-select  --query           --verbose
$ h1 vm create --type a1.n<TAB> # completes full flavour name automatically
$ h1 vm create --type a<TAB> # completes common flavours part eg. "a1."
$ h1 vm create --type a1.<TAB> # suggest flavour names
a1.large   a1.medium  a1.micro   a1.nano    a1.small
```

For debugging use following command:

```bash
$ h1 --compbash --compgen _ _ "h1 vm create --type 58ac"
58ac418566e7477bd7bc4e0c
58ac4185ae24388c3083cb29
58ac4185beda7985f43ef235
58ac4185f379ecfc251dbdb7
58ac4185026a5824d5f36cf9
58ac4185b62cac5938c791d9
58ac4185edf331963957317c
58ac4185f25d88f25aae4b40
58ac418578b93e64fca5ba18
58ac418565159fac71f33b03
58ac4185814376abc34fa19f
58ac4185beaa7be5822d03d8
58ac4185e01afc73b1547956
58ac4185d2b20566c055b6a9
58ac418510b542811d217afc
58ac41855ec5d15da060a4b7
58ac41857e30a7b45ed996be
58ac41855cb67ae69b3d4e34
58ac4185bf27e9eaa7108af4
58ac41855f0c07ba11843676
58ac418547e0f45ffb309459
```

I am looking forward to your comments. I see the possibility of development, but in my opinion we have covered a significant number of cases when there is a need to use autocomplete.
