### PR TITLE
[WIP] Improve NodeJS tests

### DIFF
--- a/bin/website/tests.js
+++ b/bin/website/tests.js
@@ -235,7 +235,10 @@ const languages = {
     php: '<?php error_reporting(E_ALL); file_put_contents("/data/public/test.txt", "TOKEN"); ?>',
     node: `const rand = Math.random();
     require('http').createServer(
-        (req, res) => res.end(rand.toString())
+        (req, res) => {
+            console.log(new Date());
+            return res.end(rand.toString())
+        }
     ).listen(process.env.PORT);`,
     // Warning: Python is tab-sensitive
     python: `

--- a/monitoring/run_monitoring.js
+++ b/monitoring/run_monitoring.js
@@ -203,7 +203,7 @@ const parseMetric = async (conn, line) => {
             run: startTime,
         });
     } else if (line.includes(' ◌ ')) {
-        const [, title] = line.match(' ◌ (.+?)$');
+        const [, title] = line.trim().match(' *◌ (.+?)$');
         return sendInflux(conn, 'testcase', {
             title,
             result: 'timeout',


### PR DESCRIPTION
We have issues in reporting timeout in InfluxDB due of:

```
syslog.7.gz:Apr  8 05:29:55 docker-node-2 3091269b36c2[815]:   ✖ Timed out while running tests
syslog.7.gz:Apr  8 05:29:55 docker-node-2 3091269b36c2[815]: 
syslog.7.gz:Apr  8 05:29:55 docker-node-2 3091269b36c2[815]:   2 tests were pending in /src/bin/website/tests.js
syslog.7.gz:Apr  8 05:29:55 docker-node-2 3091269b36c2[815]: 
syslog.7.gz:Apr  8 05:29:55 docker-node-2 3091269b36c2[815]:   ◌ website restart nodejs app
syslog.7.gz:Apr  8 05:29:55 docker-node-2 3091269b36c2[815]:   ◌ website serve python app
syslog.7.gz:Apr  8 05:29:55 docker-node-2 3091269b36c2[815]: 
syslog.7.gz:Apr  8 05:29:55 docker-node-2 3091269b36c2[815]: TypeError: object null is not iterable (cannot read property Symbol(Symbol.iterator))
syslog.7.gz:Apr  8 05:29:55 docker-node-2 3091269b36c2[815]:     at parseMetric (/src/monitoring/run_monitoring.js:195:33)
syslog.7.gz:Apr  8 05:29:55 docker-node-2 3091269b36c2[815]:     at Socket.<anonymous> (/src/monitoring/run_monitoring.js:252:20)
syslog.7.gz:Apr  8 05:29:55 docker-node-2 3091269b36c2[815]:     at Socket.emit (events.js:311:20)
syslog.7.gz:Apr  8 05:29:55 docker-node-2 3091269b36c2[815]:     at addChunk (_stream_readable.js:294:12)
syslog.7.gz:Apr  8 05:29:55 docker-node-2 3091269b36c2[815]:     at readableAddChunk (_stream_readable.js:275:11)
syslog.7.gz:Apr  8 05:29:55 docker-node-2 3091269b36c2[815]:     at Socket.Readable.push (_stream_readable.js:209:10)
syslog.7.gz:Apr  8 05:29:55 docker-node-2 3091269b36c2[815]:     at Pipe.onStreamRead (internal/stream_base_commons.js:186:23)
syslog.7.gz:Apr  8 05:29:55 docker-node-2 3091269b36c2[815]: 
```

I would like add any logging to NodeJS demo app in website too, so I see if requests hit app. It was requested during troubleshooting bug in website-agent:
```
provider-traefik | time="2020-04-14T14:04:09Z" level=warning msg="unable to find the IP address for the container \"/5e95c21f67dfa78866771b27\": the server is ignored"
```

Result in 404 on public-side.

I am going to deploy that, but I would like not merge that until agent is fixed. I would like verify fix in regexp too.