### PR TITLE
vault@tests: Verify each entrypoint for Vault

### DIFF
--- a/lib/ssh.js
+++ b/lib/ssh.js
@@ -42,10 +42,10 @@ const getConnection = async (options = {}) => {
     throw last_err;
 };
 
-const execute = (command, connection) => new Promise((resolve, reject) =>
+const execute = (command, connection) => new Promise((resolve, reject) => {
+    console.log(new Date().toISOString(), `[host: ${connection.host}]`, command);
     getConnection(connection).then(conn => {
         const buffer = [];
-        console.log(`[${connection.host}]:${command}`);
         conn.exec(command, (err, stream) => {
             if (err) return reject({
                 msg: 'Unable to execute SSH command',
@@ -70,8 +70,8 @@ const execute = (command, connection) => new Promise((resolve, reject) =>
                 .on('data', data => buffer.push(data))
                 .stderr.on('data', data => buffer.push(data));
         });
-    }).catch(reject)
-);
+    }).catch(reject);
+});
 
 const getSftpStream = (connection) => new Promise((resolve, reject) =>
     getConnection(connection).then(conn => {


### PR DESCRIPTION
The customer has the right to expect that each access point (IP address) of the Vault service indicated to him would allow connection to the service. I have developed the test to verify the test with this ordinance. This was built in such a way that the log contains information about the first invalid host.