### PR TITLE
vm@tests: Tests preserve license

### DIFF
--- a/bin/image/tests.js
+++ b/bin/image/tests.js
@@ -48,3 +48,26 @@ ava.serial('image resolver prefer server', async t => {
     t.true(description.edition === 'server');
     t.true(description.distro === 'ubuntu');
 });
+
+ava.serial('image preserve license', async t => {
+    const disk_name = tests.getName('disk', t.title);
+    // create vm from recommended image
+    const vm_recommended = await tests.run(`vm create --type a1.nano --name ${tests.getName('vm recommended', t.title)} --image rhel --os-disk ${disk_name},ssd,40 --no-start`);
+    const vm_services = await tests.run(`vm service list --vm ${vm_recommended.id}`);
+    t.true(vm_services.some(x => x.type == 'license'));
+    // create image of vm
+    const image = await tests.run(`image create --name ${tests.getName('image', 1, t.title)} --vm ${vm_recommended.id}`);
+    t.true(image.license && image.license.length > 0);
+    // clean up vm from recommended image
+    await tests.remove('vm', vm_recommended);
+    await tests.remove('disk', disk_name);
+    // create vm from user image (with license)
+    const vm_user = await tests.run(`vm create --type a1.nano --name ${tests.getName('vm user', t.title)} --image ${image.id} --os-disk ${disk_name},ssd,40 --no-start`);
+    const vm_user_services = await tests.run(`vm service list --vm ${vm_user.id}`);
+    t.true(vm_user_services.some(x => x.type == 'license'));
+    // clean up vm from user image
+    await tests.remove('image', image);
+    // clean up vm from user image
+    await tests.remove('vm', vm_user);
+    await tests.remove('disk', disk_name);
+});


### PR DESCRIPTION
```bash
2020-05-25T12:26:55.297Z node h1 vm create --type a1.nano --name vm-recommended-image-preserve-license-1590409615287 --image rhel --os-disk disk-image-preserve-license-1590409615287\,ssd\,40 --no-start -o js
2020-05-25T12:27:41.700Z node h1 vm service list --vm 5ecbb9928073de470f1cf6ac -o js
2020-05-25T12:27:42.512Z node h1 image create --name image-1-image-preserve-license-1590409662504 --vm 5ecbb9928073de470f1cf6ac -o js
2020-05-25T12:27:55.203Z node h1 vm delete --vm 5ecbb9928073de470f1cf6ac --yes -o js
2020-05-25T12:28:01.606Z node h1 disk delete --disk disk-image-preserve-license-1590409615287 --yes -o js
2020-05-25T12:28:03.969Z node h1 vm create --type a1.nano --name vm-user-image-preserve-license-1590409683964 --image 5ecbb9bf8073de470f1cf6df --os-disk disk-image-preserve-license-1590409615287\,ssd\,40 --no-start -o js
2020-05-25T12:28:41.677Z node h1 vm service list --vm 5ecbb9d58073de470f1cf700 -o js
2020-05-25T12:28:42.492Z node h1 image delete --image 5ecbb9bf8073de470f1cf6df --yes -o js
2020-05-25T12:28:47.102Z node h1 vm delete --vm 5ecbb9d58073de470f1cf700 --yes -o js
2020-05-25T12:28:53.694Z node h1 disk delete --disk disk-image-preserve-license-1590409615287 --yes -o js
  ✔ bin › image › tests › image preserve license (2m 0.6s)
```