### PR TITLE
add uri to generateQuery

### DIFF
--- a/extensions/cli-ext-root-openapi-generator/request.js
+++ b/extensions/cli-ext-root-openapi-generator/request.js
@@ -244,7 +244,7 @@ const generateQuery = (path, operation) => {
     }
 
     if (props) {
-        for (const name of ['id', 'name', 'state', 'flavour', 'content', 'enabled', 'size']) {
+        for (const name of ['id', 'name', 'state', 'flavour', 'content', 'enabled', 'size', 'uri']) {
             if (props[name]) {
                 col.push(`${name}:${name}`);
             }


### PR DESCRIPTION
When setting output format to "uri" there is blank line for each item shown.

This is due to generation of defaultQuery by generateQuery which filters out "uri" from objects returned from API.

This PR is just a quick fix for situations when generateQuery is used (most cases), it doesn't fix it for cases where there is specific `defaultQuery` set for command.  

Further work required in order to fix it in more generic way.

 